### PR TITLE
prefixed internal functions with fpp_

### DIFF
--- a/cpp.h
+++ b/cpp.h
@@ -35,9 +35,9 @@
 
 #include <stdlib.h>
 #include <string.h>
-#ifndef toupper
-#define toupper(c) ((c) + ('A' - 'a'))
-#endif /* no toupper */
+#ifndef fpp_toupper
+#define fpp_toupper(c) ((c) + ('A' - 'a'))
+#endif /* no fpp_toupper */
 #ifndef tolower
 #define tolower(c) ((c) + ('a' - 'A'))
 #endif /* no tolower */

--- a/cpp.h
+++ b/cpp.h
@@ -52,7 +52,7 @@
  */
 #define EOS		'\0'            /* End of string                */
 #endif
-#define EOF_CHAR	0		/* Returned by get() on eof     */
+#define EOF_CHAR	0		/* Returned by fpp_get() on eof     */
 #define NULLST		((char *) NULL) /* Pointer to nowhere (linted)  */
 #define DEF_NOARGS	(-1)            /* #define foo vs #define foo() */
 

--- a/cpp.h
+++ b/cpp.h
@@ -38,9 +38,9 @@
 #ifndef fpp_toupper
 #define fpp_toupper(c) ((c) + ('A' - 'a'))
 #endif /* no fpp_toupper */
-#ifndef tolower
-#define tolower(c) ((c) + ('a' - 'A'))
-#endif /* no tolower */
+#ifndef fpp_tolower
+#define fpp_tolower(c) ((c) + ('a' - 'A'))
+#endif /* no fpp_tolower */
 
 #ifndef FPP_TRUE
 #define FPP_TRUE		1

--- a/cpp.h
+++ b/cpp.h
@@ -42,9 +42,9 @@
 #define tolower(c) ((c) + ('a' - 'A'))
 #endif /* no tolower */
 
-#ifndef TRUE
-#define TRUE		1
-#define FALSE		0
+#ifndef FPP_TRUE
+#define FPP_TRUE		1
+#define FPP_FALSE		0
 #endif
 #ifndef EOS
 /*
@@ -139,9 +139,9 @@
 /*
  * These bits are set in ifstack[]
  */
-#define WAS_COMPILING	1		/* TRUE if compile set at entry */
-#define ELSE_SEEN	2		/* TRUE when #else processed	*/
-#define TRUE_SEEN	4		/* TRUE when #if TRUE processed */
+#define WAS_COMPILING	1		/* FPP_TRUE if compile set at entry */
+#define ELSE_SEEN	2		/* FPP_TRUE when #else processed	*/
+#define FPP_TRUE_SEEN	4		/* FPP_TRUE when #if FPP_TRUE processed */
 
 /*
  * Define bits for the basic types and their adjectives

--- a/cpp1.c
+++ b/cpp1.c
@@ -138,9 +138,9 @@ int fppPreProcess(struct fppTag *tags)
     ret=cppmain(global);             /* Process main file            */
   if ((i = (global->ifptr - global->ifstack)) != 0) {
 #if OLD_PREPROCESSOR
-    cwarn(global, ERROR_IFDEF_DEPTH, i);
+    fpp_cwarn(global, ERROR_IFDEF_DEPTH, i);
 #else
-    cerror(global, ERROR_IFDEF_DEPTH, i);
+    fpp_cerror(global, ERROR_IFDEF_DEPTH, i);
 #endif
   }
   fflush(stdout);
@@ -481,13 +481,13 @@ ReturnCode cppmain(struct Global *global)
 
   if(global->showbalance) {
     if(bracketlevel) {
-      cwarn(global, WARN_BRACKET_DEPTH, bracketlevel);
+      fpp_cwarn(global, WARN_BRACKET_DEPTH, bracketlevel);
     }
     if(parenlevel) {
-      cwarn(global, WARN_PAREN_DEPTH, parenlevel);
+      fpp_cwarn(global, WARN_PAREN_DEPTH, parenlevel);
     }
     if(bracelevel) {
-      cwarn(global, WARN_BRACE_DEPTH, bracelevel);
+      fpp_cwarn(global, WARN_BRACE_DEPTH, bracelevel);
     }
   }
   if (global->wflag) {

--- a/cpp1.c
+++ b/cpp1.c
@@ -55,17 +55,17 @@ int fppPreProcess(struct fppTag *tags)
   global->wrongline=0;
   global->errors=0;
   global->recursion=0;
-  global->rec_recover=TRUE;
-  global->instring=FALSE;
-  global->inmacro=FALSE;
+  global->rec_recover=FPP_TRUE;
+  global->instring=FPP_FALSE;
+  global->inmacro=FPP_FALSE;
   global->workp=NULL;
-  global->keepcomments = FALSE;  /* Write out comments flag     */
-  global->cflag = FALSE;          /* -C option (keep comments)    */
-  global->eflag = FALSE;          /* -E option (never fail)       */
+  global->keepcomments = FPP_FALSE;  /* Write out comments flag     */
+  global->cflag = FPP_FALSE;          /* -C option (keep comments)    */
+  global->eflag = FPP_FALSE;          /* -E option (never fail)       */
   global->nflag = 0;              /* -N option (no predefines)    */
-  global->wflag = FALSE;          /* -W option (write #defines)   */
+  global->wflag = FPP_FALSE;          /* -W option (write #defines)   */
 
-  global->ifstack[0]=TRUE;       /* #if information     */
+  global->ifstack[0]=FPP_TRUE;       /* #if information     */
   global->ifptr = global->ifstack;
   global->incend = global->incdir;
 
@@ -106,23 +106,23 @@ int fppPreProcess(struct fppTag *tags)
   global->first_file=NULL;
   global->userdata=NULL;
 
-  global->linelines=TRUE;
-  global->warnillegalcpp = FALSE;
-  global->outputLINE = TRUE;
-  global->warnnoinclude = TRUE;
-  global->showversion = TRUE;
-  global->showincluded = FALSE;
-  global->showspace = FALSE;
-  global->nestcomments = FALSE;
-  global->warnnestcomments = FALSE;
-  global->outputfile = TRUE;
+  global->linelines=FPP_TRUE;
+  global->warnillegalcpp = FPP_FALSE;
+  global->outputLINE = FPP_TRUE;
+  global->warnnoinclude = FPP_TRUE;
+  global->showversion = FPP_TRUE;
+  global->showincluded = FPP_FALSE;
+  global->showspace = FPP_FALSE;
+  global->nestcomments = FPP_FALSE;
+  global->warnnestcomments = FPP_FALSE;
+  global->outputfile = FPP_TRUE;
   global->included = 0;
 
-  global->comment = FALSE;
-  global->rightconcat = FALSE;
+  global->comment = FPP_FALSE;
+  global->rightconcat = FPP_FALSE;
   global->work[0] = '\0';
   global->initialfunc = NULL;
-  global->allowincludelocal = TRUE;
+  global->allowincludelocal = FPP_TRUE;
 
   memset(global->symtab, 0, SBSIZE * sizeof(DEFBUF *));
 
@@ -209,7 +209,7 @@ ReturnCode cppmain(struct Global *global)
     sharp(global);
   /*
    * This loop is started "from the top" at the beginning of each line
-   * wrongline is set TRUE in many places if it is necessary to write
+   * wrongline is set FPP_TRUE in many places if it is necessary to write
    * a #line record.  (But we don't write them when expanding macros.)
    *
    * The counter variable has two different uses:  at
@@ -225,13 +225,13 @@ ReturnCode cppmain(struct Global *global)
   include = global->included;
 
   while(include--) {
-    openinclude(global, global->include[(unsigned)include], TRUE);
+    openinclude(global, global->include[(unsigned)include], FPP_TRUE);
   }
   
   for (;;) {
     counter = 0;                        /* Count empty lines    */
     for (;;) {                          /* For each line, ...   */
-      global->comment = FALSE;          /* No comment yet!      */
+      global->comment = FPP_FALSE;          /* No comment yet!      */
       global->chpos = 0;                /* Count whitespaces    */
       while (type[(c = get(global))] == SPA)  /* Skip leading blanks */
 	if(global->showspace) {
@@ -248,7 +248,7 @@ ReturnCode cppmain(struct Global *global)
 	  ++counter;                    /* Do nothing now       */
       }
       else if (c == '#') {              /* Is 1st non-space '#' */
-	global->keepcomments = FALSE;   /* Don't pass comments  */
+	global->keepcomments = FPP_FALSE;   /* Don't pass comments  */
 	ret = control(global, &counter); /* Yes, do a #command   */
 	if(ret)
 	  return(ret);
@@ -388,7 +388,7 @@ ReturnCode cppmain(struct Global *global)
 		if(a==global->excluded) {
 		    expstuff(global, "__brace__", "{");
 		    expstuff(global, "__init_func__", global->initialfunc);
-		    initfunc = TRUE;
+		    initfunc = FPP_TRUE;
 		}
 	    }
 
@@ -475,7 +475,7 @@ ReturnCode cppmain(struct Global *global)
     if (c == '\n') {  /* Compiling at EOL?    */
       Putchar(global, '\n');              /* Output newline, if   */
       if (global->infile->fp == NULL)     /* Expanding a macro,   */
-	global->wrongline = TRUE; /* Output # line later        */
+	global->wrongline = FPP_TRUE; /* Output # line later        */
     }
   }                             /* Continue until EOF   */
 
@@ -491,7 +491,7 @@ ReturnCode cppmain(struct Global *global)
     }
   }
   if (global->wflag) {
-    global->out = TRUE;         /* enable output */
+    global->out = FPP_TRUE;         /* enable output */
     outdefines(global);         /* Write out #defines   */
   }
   return(FPP_OK);
@@ -592,6 +592,6 @@ void sharp(struct Global *global)
     }
   }
   Putchar(global, '\n');
-  global->wrongline = FALSE;
+  global->wrongline = FPP_FALSE;
   return;
 }

--- a/cpp1.c
+++ b/cpp1.c
@@ -35,7 +35,7 @@ void __stdargs _XCEXIT(long a) { return; }
 #endif
 
 FILE_LOCAL ReturnCode fpp_output(struct Global *, int); /* Output one character */
-FILE_LOCAL void sharp(struct Global *);
+FILE_LOCAL void fpp_sharp(struct Global *);
 INLINE FILE_LOCAL ReturnCode fpp_cppmain(struct Global *);
 
 int fppPreProcess(struct fppTag *tags)
@@ -206,7 +206,7 @@ ReturnCode fpp_cppmain(struct Global *global)
    * the name of the first #include file instead.
    */
   if(global->linelines) /* if #line lines are wanted! */
-    sharp(global);
+    fpp_sharp(global);
   /*
    * This loop is started "from the top" at the beginning of each line
    * wrongline is set FPP_TRUE in many places if it is necessary to write
@@ -272,7 +272,7 @@ ReturnCode fpp_cppmain(struct Global *global)
      */
     if(global->linelines) { /* if #line lines are wanted! */
       if ((global->wrongline && global->infile->fp != NULL) || counter > 4)
-        sharp(global);                    /* Output # line number */
+        fpp_sharp(global);                    /* Output # line number */
       else {                              /* If just a few, stuff */
         while (--counter >= 0)            /* them out ourselves   */
 	  fpp_Putchar(global, (int)'\n');
@@ -560,7 +560,7 @@ void fpp_Putint(struct Global *global, int number)
 
 
 FILE_LOCAL
-void sharp(struct Global *global)
+void fpp_sharp(struct Global *global)
 {
   /*
    * Output a line number line.

--- a/cpp1.c
+++ b/cpp1.c
@@ -386,8 +386,8 @@ ReturnCode cppmain(struct Global *global)
 			break;
 		}
 		if(a==global->excluded) {
-		    expstuff(global, "__brace__", "{");
-		    expstuff(global, "__init_func__", global->initialfunc);
+		    fpp_expstuff(global, "__brace__", "{");
+		    fpp_expstuff(global, "__init_func__", global->initialfunc);
 		    initfunc = FPP_TRUE;
 		}
 	    }

--- a/cpp1.c
+++ b/cpp1.c
@@ -249,7 +249,7 @@ ReturnCode cppmain(struct Global *global)
       }
       else if (c == '#') {              /* Is 1st non-space '#' */
 	global->keepcomments = FPP_FALSE;   /* Don't pass comments  */
-	ret = control(global, &counter); /* Yes, do a #command   */
+	ret = fpp_control(global, &counter); /* Yes, do a #command   */
 	if(ret)
 	  return(ret);
 	global->keepcomments = (global->cflag && compiling);

--- a/cpp1.c
+++ b/cpp1.c
@@ -242,7 +242,7 @@ ReturnCode cppmain(struct Global *global)
       if (c == '\n') {                  /* If line's all blank, */
 	if(global->comment) {
 	  /* A comment was output! */
-	  Putchar(global, '\n');
+	  fpp_Putchar(global, '\n');
 	}
 	else
 	  ++counter;                    /* Do nothing now       */
@@ -275,7 +275,7 @@ ReturnCode cppmain(struct Global *global)
         sharp(global);                    /* Output # line number */
       else {                              /* If just a few, stuff */
         while (--counter >= 0)            /* them out ourselves   */
-	  Putchar(global, (int)'\n');
+	  fpp_Putchar(global, (int)'\n');
       }
     }
     if(global->showspace) {
@@ -305,7 +305,7 @@ ReturnCode cppmain(struct Global *global)
 	  break;                      /* Exit line loop       */
 	else if (counter > 0) {       /* If we got any spaces */
 	  if(!global->showspace)      /* We don't output all spaces */
-	    Putchar(global, (int)' ');/* Output one space     */
+	    fpp_Putchar(global, (int)' ');/* Output one space     */
 	  else {
 	    global->spacebuf[global->chpos] = '\0';
 	    Putstring(global, global->spacebuf); /* Output all whitespaces */
@@ -404,7 +404,7 @@ ReturnCode cppmain(struct Global *global)
 	    define = 1;
 
 	    if(initfunc) {
-	      Putchar(global, '}');
+	      fpp_Putchar(global, '}');
 	      bracelevel--;
 	      initfunc=0;
 	    }
@@ -466,14 +466,14 @@ ReturnCode cppmain(struct Global *global)
 	}
 	define--; /* decrease function probability */
 	
-	Putchar(global, c);     /* Just output it       */
+	fpp_Putchar(global, c);     /* Just output it       */
 	break;
       }                         /* Switch ends          */
       prev = type[c];
     }                           /* Line for loop        */
     
     if (c == '\n') {  /* Compiling at EOL?    */
-      Putchar(global, '\n');              /* Output newline, if   */
+      fpp_Putchar(global, '\n');              /* Output newline, if   */
       if (global->infile->fp == NULL)     /* Expanding a macro,   */
 	global->wrongline = FPP_TRUE; /* Output # line later        */
     }
@@ -509,11 +509,11 @@ ReturnCode output(struct Global *global, int c)
 #else
   if (c != TOK_SEP)
 #endif
-    Putchar(global, c);
+    fpp_Putchar(global, c);
   return(FPP_OK);
 }
 
-void Putchar(struct Global *global, int c)
+void fpp_Putchar(struct Global *global, int c)
 {
   /*
    * Output one character to stdout or to output function!
@@ -533,14 +533,14 @@ void Putchar(struct Global *global, int c)
 void Putstring(struct Global *global, char *string)
 {
   /*
-   * Output a string! One letter at a time to the Putchar routine!
+   * Output a string! One letter at a time to the fpp_Putchar routine!
    */
 
   if(!string)
     return;
 
   while(*string)
-    Putchar(global, *string++);
+    fpp_Putchar(global, *string++);
 }
 
 void Putint(struct Global *global, int number)
@@ -555,7 +555,7 @@ void Putint(struct Global *global, int number)
   sprintf(buffer, "%d", number);
 
   while(*point)
-    Putchar(global, *point++);
+    fpp_Putchar(global, *point++);
 }
 
 
@@ -568,13 +568,13 @@ void sharp(struct Global *global)
 
   char *name;
   if (global->keepcomments)                     /* Make sure # comes on */
-    Putchar(global, '\n');                      /* a fresh, new line.   */
+    fpp_Putchar(global, '\n');                      /* a fresh, new line.   */
   /*  printf("#%s %d", LINE_PREFIX, global->line); */
 
-  Putchar(global, '#');
+  fpp_Putchar(global, '#');
   if(global->outputLINE)
           Putstring(global, LINE_PREFIX);
-  Putchar(global, ' ');
+  fpp_Putchar(global, ' ');
   Putint(global, global->line);
 
   if (global->infile->fp != NULL) {
@@ -588,10 +588,10 @@ void sharp(struct Global *global)
       /* printf(" \"%s\"", name); */
       Putstring(global, " \"");
       Putstring(global, name);
-      Putchar(global, '\"');
+      fpp_Putchar(global, '\"');
     }
   }
-  Putchar(global, '\n');
+  fpp_Putchar(global, '\n');
   global->wrongline = FPP_FALSE;
   return;
 }

--- a/cpp1.c
+++ b/cpp1.c
@@ -347,7 +347,7 @@ ReturnCode cppmain(struct Global *global)
 	go = 0;
 	/* Copy it to output */
         if(!global->webmode) {
-          ret=scanstring(global, c,
+          ret=fpp_scanstring(global, c,
                          (ReturnCode(*)(struct Global *, int))output);
           if(ret)
             return(ret);
@@ -502,7 +502,7 @@ ReturnCode output(struct Global *global, int c)
 {
   /*
    * Output one character to stdout -- output() is passed as an
-   * argument to scanstring()
+   * argument to fpp_scanstring()
    */
 #if COMMENT_INVISIBLE
   if (c != TOK_SEP && c != COM_SEP)

--- a/cpp1.c
+++ b/cpp1.c
@@ -257,7 +257,7 @@ ReturnCode cppmain(struct Global *global)
       else if (c == EOF_CHAR)           /* At end of file?      */
 	break;
       else if (!compiling) {            /* #ifdef false?        */
-	skipnl(global);                 /* Skip to newline      */
+	fpp_skipnl(global);                 /* Skip to newline      */
 	counter++;                      /* Count it, too.       */
       } else {
 	break;                          /* Actual token         */

--- a/cpp1.c
+++ b/cpp1.c
@@ -197,7 +197,7 @@ ReturnCode cppmain(struct Global *global)
   }
 
   if(global->showversion)
-      Error(global, VERSION_TEXT);
+      fpp_Error(global, VERSION_TEXT);
 
   /*
    * Explicitly output a #line at the start of cpp output so
@@ -372,7 +372,7 @@ ReturnCode cppmain(struct Global *global)
 			/*
 			 * Output the discovered function name to stderr!
 			 */
-			Error(global, "#> Function defined at line %d: %s <#\n",
+			fpp_Error(global, "#> Function defined at line %d: %s <#\n",
 				  global->line,
 				  global->functionname);
 		}

--- a/cpp1.c
+++ b/cpp1.c
@@ -233,7 +233,7 @@ ReturnCode cppmain(struct Global *global)
     for (;;) {                          /* For each line, ...   */
       global->comment = FPP_FALSE;          /* No comment yet!      */
       global->chpos = 0;                /* Count whitespaces    */
-      while (type[(c = get(global))] == SPA)  /* Skip leading blanks */
+      while (type[(c = fpp_get(global))] == SPA)  /* Skip leading blanks */
 	if(global->showspace) {
 	  if(global->chpos<MAX_SPACE_SIZE-1)
 	    /* we still have buffer to store this! */
@@ -290,7 +290,7 @@ ReturnCode cppmain(struct Global *global)
     unget(global);                      /* Reread the char.     */
     for (;;) {                          /* For the whole line,  */
       do {                              /* Token concat. loop   */
-	for (global->chpos = counter = 0; (type[(c = get(global))] == SPA);) {
+	for (global->chpos = counter = 0; (type[(c = fpp_get(global))] == SPA);) {
 #if COMMENT_INVISIBLE
 	  if (c != COM_SEP)
 	    counter++;

--- a/cpp1.c
+++ b/cpp1.c
@@ -313,7 +313,7 @@ ReturnCode cppmain(struct Global *global)
 	}
 	if((ret=macroid(global, &c)))   /* Grab the token       */
 	  return(ret);
-      } while (type[c] == LET && catenate(global, 0, &ret) && !ret);
+      } while (type[c] == LET && fpp_catenate(global, 0, &ret) && !ret);
       if(ret)
 	/* If the loop was broken because of a fatal error! */
 	return(ret);
@@ -339,7 +339,7 @@ ReturnCode cppmain(struct Global *global)
 	ret=scannumber(global, c, (ReturnCode(*)(struct Global *, int))output);
 	if(ret)
 	  return(ret);
-	catenate(global, 1, &ret);  /* Check to see if the number is the lhs of a macro concat */
+	fpp_catenate(global, 1, &ret);  /* Check to see if the number is the lhs of a macro concat */
 	if(ret)
 	  return(ret);
 	break;

--- a/cpp1.c
+++ b/cpp1.c
@@ -130,7 +130,7 @@ int fppPreProcess(struct fppTag *tags)
   if(ret)
     return(ret);
   dooptions(global, tags);  /* Command line -flags  */
-  ret=addfile(global, stdin, global->work); /* "open" main input file       */
+  ret=fpp_addfile(global, stdin, global->work); /* "open" main input file       */
 
   global->out = global->outputfile;
 

--- a/cpp1.c
+++ b/cpp1.c
@@ -36,7 +36,7 @@ void __stdargs _XCEXIT(long a) { return; }
 
 FILE_LOCAL ReturnCode fpp_output(struct Global *, int); /* Output one character */
 FILE_LOCAL void sharp(struct Global *);
-INLINE FILE_LOCAL ReturnCode cppmain(struct Global *);
+INLINE FILE_LOCAL ReturnCode fpp_cppmain(struct Global *);
 
 int fppPreProcess(struct fppTag *tags)
 {
@@ -135,7 +135,7 @@ int fppPreProcess(struct fppTag *tags)
   global->out = global->outputfile;
 
   if(!ret)
-    ret=cppmain(global);             /* Process main file            */
+    ret=fpp_cppmain(global);             /* Process main file            */
   if ((i = (global->ifptr - global->ifstack)) != 0) {
 #if OLD_PREPROCESSOR
     fpp_cwarn(global, ERROR_IFDEF_DEPTH, i);
@@ -152,7 +152,7 @@ int fppPreProcess(struct fppTag *tags)
 }
 
 INLINE FILE_LOCAL
-ReturnCode cppmain(struct Global *global)
+ReturnCode fpp_cppmain(struct Global *global)
 {
   /*
    * Main process for cpp -- copies tokens from the current input

--- a/cpp1.c
+++ b/cpp1.c
@@ -34,7 +34,7 @@ void __stdargs _XCEXIT(long a) { return; }
 #endif
 #endif
 
-FILE_LOCAL ReturnCode output(struct Global *, int); /* Output one character */
+FILE_LOCAL ReturnCode fpp_output(struct Global *, int); /* Output one character */
 FILE_LOCAL void sharp(struct Global *);
 INLINE FILE_LOCAL ReturnCode cppmain(struct Global *);
 
@@ -336,7 +336,7 @@ ReturnCode cppmain(struct Global *global)
       case DIG:                 /* Output a number      */
       case DOT:                 /* Dot may begin floats */
 	go = 0;
-	ret=fpp_scannumber(global, c, (ReturnCode(*)(struct Global *, int))output);
+	ret=fpp_scannumber(global, c, (ReturnCode(*)(struct Global *, int))fpp_output);
 	if(ret)
 	  return(ret);
 	fpp_catenate(global, 1, &ret);  /* Check to see if the number is the lhs of a macro concat */
@@ -348,7 +348,7 @@ ReturnCode cppmain(struct Global *global)
 	/* Copy it to output */
         if(!global->webmode) {
           ret=fpp_scanstring(global, c,
-                         (ReturnCode(*)(struct Global *, int))output);
+                         (ReturnCode(*)(struct Global *, int))fpp_output);
           if(ret)
             return(ret);
           break;
@@ -491,17 +491,17 @@ ReturnCode cppmain(struct Global *global)
     }
   }
   if (global->wflag) {
-    global->out = FPP_TRUE;         /* enable output */
+    global->out = FPP_TRUE;         /* enable fpp_output */
     fpp_outdefines(global);         /* Write out #defines   */
   }
   return(FPP_OK);
 }
 
 FILE_LOCAL
-ReturnCode output(struct Global *global, int c)
+ReturnCode fpp_output(struct Global *global, int c)
 {
   /*
-   * Output one character to stdout -- output() is passed as an
+   * Output one character to stdout -- fpp_output() is passed as an
    * argument to fpp_scanstring()
    */
 #if COMMENT_INVISIBLE
@@ -516,7 +516,7 @@ ReturnCode output(struct Global *global, int c)
 void fpp_Putchar(struct Global *global, int c)
 {
   /*
-   * Output one character to stdout or to output function!
+   * Output one character to stdout or to fpp_output function!
    */
   if(!global->out)
     return;

--- a/cpp1.c
+++ b/cpp1.c
@@ -225,7 +225,7 @@ ReturnCode cppmain(struct Global *global)
   include = global->included;
 
   while(include--) {
-    openinclude(global, global->include[(unsigned)include], FPP_TRUE);
+    fpp_openinclude(global, global->include[(unsigned)include], FPP_TRUE);
   }
   
   for (;;) {

--- a/cpp1.c
+++ b/cpp1.c
@@ -311,7 +311,7 @@ ReturnCode cppmain(struct Global *global)
 	    fpp_Putstring(global, global->spacebuf); /* Output all whitespaces */
 	  }
 	}
-	if((ret=macroid(global, &c)))   /* Grab the token       */
+	if((ret=fpp_macroid(global, &c)))   /* Grab the token       */
 	  return(ret);
       } while (type[c] == LET && fpp_catenate(global, 0, &ret) && !ret);
       if(ret)

--- a/cpp1.c
+++ b/cpp1.c
@@ -126,7 +126,7 @@ int fppPreProcess(struct fppTag *tags)
 
   memset(global->symtab, 0, SBSIZE * sizeof(DEFBUF *));
 
-  ret=initdefines(global);  /* O.S. specific def's  */
+  ret=fpp_initdefines(global);  /* O.S. specific def's  */
   if(ret)
     return(ret);
   fpp_dooptions(global, tags);  /* Command line -flags  */

--- a/cpp1.c
+++ b/cpp1.c
@@ -287,7 +287,7 @@ ReturnCode cppmain(struct Global *global)
     /*
      * Process each token on this line.
      */
-    unget(global);                      /* Reread the char.     */
+    fpp_unget(global);                      /* Reread the char.     */
     for (;;) {                          /* For the whole line,  */
       do {                              /* Token concat. loop   */
 	for (global->chpos = counter = 0; (type[(c = fpp_get(global))] == SPA);) {

--- a/cpp1.c
+++ b/cpp1.c
@@ -129,7 +129,7 @@ int fppPreProcess(struct fppTag *tags)
   ret=initdefines(global);  /* O.S. specific def's  */
   if(ret)
     return(ret);
-  dooptions(global, tags);  /* Command line -flags  */
+  fpp_dooptions(global, tags);  /* Command line -flags  */
   ret=fpp_addfile(global, stdin, global->work); /* "open" main input file       */
 
   global->out = global->outputfile;

--- a/cpp1.c
+++ b/cpp1.c
@@ -336,7 +336,7 @@ ReturnCode cppmain(struct Global *global)
       case DIG:                 /* Output a number      */
       case DOT:                 /* Dot may begin floats */
 	go = 0;
-	ret=scannumber(global, c, (ReturnCode(*)(struct Global *, int))output);
+	ret=fpp_scannumber(global, c, (ReturnCode(*)(struct Global *, int))output);
 	if(ret)
 	  return(ret);
 	fpp_catenate(global, 1, &ret);  /* Check to see if the number is the lhs of a macro concat */

--- a/cpp1.c
+++ b/cpp1.c
@@ -492,7 +492,7 @@ ReturnCode cppmain(struct Global *global)
   }
   if (global->wflag) {
     global->out = FPP_TRUE;         /* enable output */
-    outdefines(global);         /* Write out #defines   */
+    fpp_outdefines(global);         /* Write out #defines   */
   }
   return(FPP_OK);
 }

--- a/cpp1.c
+++ b/cpp1.c
@@ -584,7 +584,7 @@ void sharp(struct Global *global)
         || (global->sharpfilename != NULL && !streq(name, global->sharpfilename))) {
       if (global->sharpfilename != NULL)
         free(global->sharpfilename);
-      global->sharpfilename = savestring(global, name);
+      global->sharpfilename = fpp_savestring(global, name);
       /* printf(" \"%s\"", name); */
       fpp_Putstring(global, " \"");
       fpp_Putstring(global, name);

--- a/cpp1.c
+++ b/cpp1.c
@@ -281,7 +281,7 @@ ReturnCode cppmain(struct Global *global)
     if(global->showspace) {
       /* Show all whitespaces! */
       global->spacebuf[global->chpos] = '\0';
-      Putstring(global, global->spacebuf);
+      fpp_Putstring(global, global->spacebuf);
     }
     
     /*
@@ -308,7 +308,7 @@ ReturnCode cppmain(struct Global *global)
 	    fpp_Putchar(global, (int)' ');/* Output one space     */
 	  else {
 	    global->spacebuf[global->chpos] = '\0';
-	    Putstring(global, global->spacebuf); /* Output all whitespaces */
+	    fpp_Putstring(global, global->spacebuf); /* Output all whitespaces */
 	  }
 	}
 	if((ret=macroid(global, &c)))   /* Grab the token       */
@@ -324,7 +324,7 @@ ReturnCode cppmain(struct Global *global)
       case LET:
 	go =0;
 	/* Quite ordinary token */
-	Putstring(global, global->tokenbuf);
+	fpp_Putstring(global, global->tokenbuf);
 	
 	if(!define) {
 	  /* Copy the name */
@@ -530,7 +530,7 @@ void fpp_Putchar(struct Global *global, int c)
 #endif
 }
 
-void Putstring(struct Global *global, char *string)
+void fpp_Putstring(struct Global *global, char *string)
 {
   /*
    * Output a string! One letter at a time to the fpp_Putchar routine!
@@ -573,7 +573,7 @@ void sharp(struct Global *global)
 
   fpp_Putchar(global, '#');
   if(global->outputLINE)
-          Putstring(global, LINE_PREFIX);
+          fpp_Putstring(global, LINE_PREFIX);
   fpp_Putchar(global, ' ');
   Putint(global, global->line);
 
@@ -586,8 +586,8 @@ void sharp(struct Global *global)
         free(global->sharpfilename);
       global->sharpfilename = savestring(global, name);
       /* printf(" \"%s\"", name); */
-      Putstring(global, " \"");
-      Putstring(global, name);
+      fpp_Putstring(global, " \"");
+      fpp_Putstring(global, name);
       fpp_Putchar(global, '\"');
     }
   }

--- a/cpp1.c
+++ b/cpp1.c
@@ -543,7 +543,7 @@ void fpp_Putstring(struct Global *global, char *string)
     fpp_Putchar(global, *string++);
 }
 
-void Putint(struct Global *global, int number)
+void fpp_Putint(struct Global *global, int number)
 {
   /*
    * Output the number as a string.
@@ -575,7 +575,7 @@ void sharp(struct Global *global)
   if(global->outputLINE)
           fpp_Putstring(global, LINE_PREFIX);
   fpp_Putchar(global, ' ');
-  Putint(global, global->line);
+  fpp_Putint(global, global->line);
 
   if (global->infile->fp != NULL) {
     name = (global->infile->progname != NULL)

--- a/cpp2.c
+++ b/cpp2.c
@@ -30,7 +30,7 @@ SOFTWARE.
 
 FILE_LOCAL void fpp_dump_line(struct Global *, int *);
 FILE_LOCAL ReturnCode fpp_doif(struct Global *, int);
-INLINE FILE_LOCAL ReturnCode doinclude(struct Global *);
+INLINE FILE_LOCAL ReturnCode fpp_doinclude(struct Global *);
 INLINE FILE_LOCAL int hasdirectory(char *, char *);
 
 
@@ -247,7 +247,7 @@ ReturnCode fpp_control( struct Global *global,
             break;
 
         case L_include:
-            ret = doinclude( global );
+            ret = fpp_doinclude( global );
             if( ret )
                 return(ret);
             break;
@@ -533,7 +533,7 @@ ReturnCode fpp_doif(struct Global *global, int hash)
 }
 
 INLINE FILE_LOCAL
-ReturnCode doinclude( struct Global *global )
+ReturnCode fpp_doinclude( struct Global *global )
 {
     /*
      *  Process the #include control line.
@@ -619,7 +619,7 @@ ReturnCode fpp_openinclude( struct Global *global,
 {
     /*
      * Actually open an include file.  This routine is only called from
-     * doinclude() above, but was written as a separate subroutine for
+     * fpp_doinclude() above, but was written as a separate subroutine for
      * programmer convenience.  It searches the list of directories
      * and actually opens the file, linking it into the list of
      * active files.  Returns ReturnCode. No error message is printed.

--- a/cpp2.c
+++ b/cpp2.c
@@ -240,7 +240,7 @@ ReturnCode control( struct Global *global,
                     /* Give up the old name if it's allocated.   */
                     free( global->infile->progname );
 
-                global->infile->progname = savestring( global, tp );
+                global->infile->progname = fpp_savestring( global, tp );
                 }
 
             global->wrongline = FPP_TRUE;           /* Force output later   */

--- a/cpp2.c
+++ b/cpp2.c
@@ -29,7 +29,7 @@ SOFTWARE.
 #endif
 
 FILE_LOCAL void fpp_dump_line(struct Global *, int *);
-FILE_LOCAL ReturnCode doif(struct Global *, int);
+FILE_LOCAL ReturnCode fpp_doif(struct Global *, int);
 INLINE FILE_LOCAL ReturnCode doinclude(struct Global *);
 INLINE FILE_LOCAL int hasdirectory(char *, char *);
 
@@ -320,7 +320,7 @@ ReturnCode fpp_control( struct Global *global,
                 return( FPP_OK );
                 }
 
-            ret = doif( global, L_if );
+            ret = fpp_doif( global, L_if );
 
             if( ret )
                 return(ret);
@@ -338,7 +338,7 @@ ReturnCode fpp_control( struct Global *global,
                 {
                 *global->ifptr = WAS_COMPILING;
 
-                ret = doif( global, hash );
+                ret = fpp_doif( global, hash );
 
                 if( ret )
                     return(ret);
@@ -458,13 +458,13 @@ void fpp_dump_line(struct Global *global, int *counter)
 }
 
 FILE_LOCAL
-ReturnCode doif(struct Global *global, int hash)
+ReturnCode fpp_doif(struct Global *global, int hash)
 {
     /*
      * Process an #if, #ifdef, or #ifndef. The latter two are straightforward,
      * while #if needs a subroutine of its own to evaluate the expression.
      *
-     * doif() is called only if compiling is FPP_TRUE.  If false, compilation
+     * fpp_doif() is called only if compiling is FPP_TRUE.  If false, compilation
      * is always supressed, so we don't need to evaluate anything.  This
      * supresses unnecessary warnings.
      */

--- a/cpp2.c
+++ b/cpp2.c
@@ -439,7 +439,7 @@ ReturnCode fpp_control( struct Global *global,
             {
             fpp_cwarn( global, WARN_UNEXPECTED_TEXT_IGNORED );
 
-            skipnl( global );
+            fpp_skipnl( global );
             }
         #endif
         }
@@ -452,7 +452,7 @@ ReturnCode fpp_control( struct Global *global,
 FILE_LOCAL
 void dump_line(struct Global *global, int *counter)
 {
-    skipnl( global );         /* Ignore rest of line  */
+    fpp_skipnl( global );         /* Ignore rest of line  */
 
     (*counter)++;
 }
@@ -480,7 +480,7 @@ ReturnCode doif(struct Global *global, int hash)
         fpp_cerror( global, ERROR_MISSING_ARGUMENT );
 
         #if !OLD_PREPROCESSOR
-        skipnl( global );               /* Prevent an extra     */
+        fpp_skipnl( global );               /* Prevent an extra     */
 
         fpp_unget( global );                /* Error message        */
         #endif
@@ -509,7 +509,7 @@ ReturnCode doif(struct Global *global, int hash)
             fpp_cerror( global, ERROR_MISSING_ARGUMENT );
 
             #if !OLD_PREPROCESSOR
-            skipnl( global );             /* Prevent an extra     */
+            fpp_skipnl( global );             /* Prevent an extra     */
 
             fpp_unget( global );              /* Error message        */
             #endif

--- a/cpp2.c
+++ b/cpp2.c
@@ -208,7 +208,7 @@ ReturnCode control( struct Global *global,
                 if( (ret = save( global, c )) )
                     return(ret);
 
-                c = get( global );
+                c = fpp_get( global );
                 }
 
             unget( global );
@@ -390,7 +390,7 @@ ReturnCode control( struct Global *global,
              */
             Putstring( global, "#pragma " );
 
-            while( (c = get( global ) ) != '\n' && c != EOF_CHAR )
+            while( (c = fpp_get( global ) ) != '\n' && c != EOF_CHAR )
                 Putchar( global, c );
 
             unget( global );
@@ -413,7 +413,7 @@ ReturnCode control( struct Global *global,
             Putstring( global, global->tokenbuf );
             Putchar( global, ' ' );
 
-            while( (c = get( global ) ) != '\n' && c != EOF_CHAR )
+            while( (c = fpp_get( global ) ) != '\n' && c != EOF_CHAR )
                 Putchar( global, c );
 
             unget( global );
@@ -574,7 +574,7 @@ ReturnCode doinclude( struct Global *global )
 
     global->workp = global->work;
 
-    while( (c = get(global)) != '\n' && c != EOF_CHAR )
+    while( (c = fpp_get(global)) != '\n' && c != EOF_CHAR )
         if( (ret = save( global, c )) )       /* Put it away.                */
             return( ret );
 

--- a/cpp2.c
+++ b/cpp2.c
@@ -559,7 +559,7 @@ ReturnCode doinclude( struct Global *global )
 
     delim = fpp_skipws( global );
 
-    if( (ret = macroid( global, &delim )) )
+    if( (ret = fpp_macroid( global, &delim )) )
         return(ret);
 
     if( delim != '<' && delim != '"' )

--- a/cpp2.c
+++ b/cpp2.c
@@ -388,7 +388,7 @@ ReturnCode control( struct Global *global,
              * #pragma is provided to pass "options" to later
              * passes of the compiler.  cpp doesn't have any yet.
              */
-            Putstring( global, "#pragma " );
+            fpp_Putstring( global, "#pragma " );
 
             while( (c = fpp_get( global ) ) != '\n' && c != EOF_CHAR )
                 fpp_Putchar( global, c );
@@ -410,7 +410,7 @@ ReturnCode control( struct Global *global,
                 cwarn( global, WARN_ILLEGAL_COMMAND, global->tokenbuf );
 
             fpp_Putchar( global, '#' );
-            Putstring( global, global->tokenbuf );
+            fpp_Putstring( global, global->tokenbuf );
             fpp_Putchar( global, ' ' );
 
             while( (c = fpp_get( global ) ) != '\n' && c != EOF_CHAR )

--- a/cpp2.c
+++ b/cpp2.c
@@ -28,7 +28,7 @@ SOFTWARE.
 #include <proto/dos.h>
 #endif
 
-FILE_LOCAL void dump_line(struct Global *, int *);
+FILE_LOCAL void fpp_dump_line(struct Global *, int *);
 FILE_LOCAL ReturnCode doif(struct Global *, int);
 INLINE FILE_LOCAL ReturnCode doinclude(struct Global *);
 INLINE FILE_LOCAL int hasdirectory(char *, char *);
@@ -177,7 +177,7 @@ ReturnCode fpp_control( struct Global *global,
             case L_undef:           /*     aren't           */
             case L_assert:          /*  compiling.  */
             case L_error:
-                dump_line( global, counter );       /* Ignore rest of line  */
+                fpp_dump_line( global, counter );       /* Ignore rest of line  */
                 return(FPP_OK);
             }
         }
@@ -267,7 +267,7 @@ ReturnCode fpp_control( struct Global *global,
                 {
                 fpp_cerror( global, ERROR_STRING_MUST_BE_IF, global->tokenbuf );
 
-                dump_line( global, counter );
+                fpp_dump_line( global, counter );
 
                 return( FPP_OK );
                 }
@@ -275,7 +275,7 @@ ReturnCode fpp_control( struct Global *global,
                 {
                 fpp_cerror( global, ERROR_STRING_MAY_NOT_FOLLOW_ELSE, global->tokenbuf );
 
-                dump_line( global, counter );
+                fpp_dump_line( global, counter );
 
                 return( FPP_OK );
                 }
@@ -298,7 +298,7 @@ ReturnCode fpp_control( struct Global *global,
                 {
                 fpp_cerror( global, ERROR_STRING_MUST_BE_IF, global->tokenbuf );
 
-                dump_line( global, counter );
+                fpp_dump_line( global, counter );
 
                 return( FPP_OK );
                 }
@@ -306,7 +306,7 @@ ReturnCode fpp_control( struct Global *global,
                 {
                 fpp_cerror( global, ERROR_STRING_MAY_NOT_FOLLOW_ELSE, global->tokenbuf );
 
-                dump_line( global, counter );
+                fpp_dump_line( global, counter );
 
                 return( FPP_OK );
                 }
@@ -315,7 +315,7 @@ ReturnCode fpp_control( struct Global *global,
                 {
                 compiling = FPP_FALSE;        /* Done compiling stuff */
 
-                dump_line( global, counter );   /* Skip this clause */
+                fpp_dump_line( global, counter );   /* Skip this clause */
 
                 return( FPP_OK );
                 }
@@ -355,7 +355,7 @@ ReturnCode fpp_control( struct Global *global,
                 {
                 fpp_cerror( global, ERROR_STRING_MUST_BE_IF, global->tokenbuf );
 
-                dump_line( global, counter );
+                fpp_dump_line( global, counter );
 
                 return(FPP_OK);
                 }
@@ -431,7 +431,7 @@ ReturnCode fpp_control( struct Global *global,
          *      #if foo
          *      #endif  foo
          */
-        dump_line( global, counter );         /* Take common exit */
+        fpp_dump_line( global, counter );         /* Take common exit */
 
         return( FPP_OK );
         #else
@@ -450,7 +450,7 @@ ReturnCode fpp_control( struct Global *global,
 }
 
 FILE_LOCAL
-void dump_line(struct Global *global, int *counter)
+void fpp_dump_line(struct Global *global, int *counter)
 {
     fpp_skipnl( global );         /* Ignore rest of line  */
 

--- a/cpp2.c
+++ b/cpp2.c
@@ -259,7 +259,7 @@ ReturnCode fpp_control( struct Global *global,
             break;
 
         case L_undef:
-            doundef( global );
+            fpp_doundef( global );
             break;
 
         case L_else:

--- a/cpp2.c
+++ b/cpp2.c
@@ -243,7 +243,7 @@ ReturnCode control( struct Global *global,
                 global->infile->progname = savestring( global, tp );
                 }
 
-            global->wrongline = TRUE;           /* Force output later   */
+            global->wrongline = FPP_TRUE;           /* Force output later   */
             break;
 
         case L_include:
@@ -284,11 +284,11 @@ ReturnCode control( struct Global *global,
 
             if( (*global->ifptr & WAS_COMPILING) != 0 )
                 {
-                if( compiling || (*global->ifptr & TRUE_SEEN) != 0 )
-                    compiling = FALSE;
+                if( compiling || (*global->ifptr & FPP_TRUE_SEEN) != 0 )
+                    compiling = FPP_FALSE;
                 else
                     {
-                    compiling = TRUE;
+                    compiling = FPP_TRUE;
                     }
                 }
             break;
@@ -311,9 +311,9 @@ ReturnCode control( struct Global *global,
                 return( FPP_OK );
                 }
 
-            if( (*global->ifptr & (WAS_COMPILING | TRUE_SEEN)) != WAS_COMPILING )
+            if( (*global->ifptr & (WAS_COMPILING | FPP_TRUE_SEEN)) != WAS_COMPILING )
                 {
-                compiling = FALSE;        /* Done compiling stuff */
+                compiling = FPP_FALSE;        /* Done compiling stuff */
 
                 dump_line( global, counter );   /* Skip this clause */
 
@@ -361,7 +361,7 @@ ReturnCode control( struct Global *global,
                 }
 
             if( !compiling && (*global->ifptr & WAS_COMPILING) != 0 )
-                global->wrongline = TRUE;
+                global->wrongline = FPP_TRUE;
 
             compiling = ((*global->ifptr & WAS_COMPILING) != 0);
 
@@ -464,7 +464,7 @@ ReturnCode doif(struct Global *global, int hash)
      * Process an #if, #ifdef, or #ifndef. The latter two are straightforward,
      * while #if needs a subroutine of its own to evaluate the expression.
      *
-     * doif() is called only if compiling is TRUE.  If false, compilation
+     * doif() is called only if compiling is FPP_TRUE.  If false, compilation
      * is always supressed, so we don't need to evaluate anything.  This
      * supresses unnecessary warnings.
      */
@@ -497,7 +497,7 @@ ReturnCode doif(struct Global *global, int hash)
         if( ret )
             return( ret );
 
-        found = (found != 0);     /* Evaluate expr, != 0 is  TRUE */
+        found = (found != 0);     /* Evaluate expr, != 0 is  FPP_TRUE */
 
         hash = L_ifdef;       /* #if is now like #ifdef */
         }
@@ -522,12 +522,12 @@ ReturnCode doif(struct Global *global, int hash)
 
     if( found == (hash == L_ifdef) )
         {
-        compiling = TRUE;
+        compiling = FPP_TRUE;
 
-        *global->ifptr |= TRUE_SEEN;
+        *global->ifptr |= FPP_TRUE_SEEN;
         }
     else
-        compiling = FALSE;
+        compiling = FPP_FALSE;
 
     return(FPP_OK);
 }
@@ -615,7 +615,7 @@ ReturnCode MultiAssignLoad( struct Global *global, char *incptr, char *filename,
 
 ReturnCode openinclude( struct Global *global,
     char *filename,     /* Input file name         */
-    int searchlocal )   /* TRUE if #include "file" */
+    int searchlocal )   /* FPP_TRUE if #include "file" */
 {
     /*
      * Actually open an include file.  This routine is only called from
@@ -690,19 +690,19 @@ int hasdirectory( char *source,   /* Directory to examine         */
     /*
      * If a device or directory is found in the source filename string, the
      * node/device/directory part of the string is copied to result and
-     * hasdirectory returns TRUE.  Else, nothing is copied and it returns FALSE.
+     * hasdirectory returns FPP_TRUE.  Else, nothing is copied and it returns FPP_FALSE.
      */
 
     char *tp2;
 
     if( (tp2 = strrchr( source, '/' ) ) == NULL )
-        return(FALSE);
+        return(FPP_FALSE);
 
     strncpy( result, source, tp2 - source + 1 );
 
     result[tp2 - source + 1] = EOS;
 
-    return( TRUE );
+    return( FPP_TRUE );
 }
 
 #ifdef _AMIGA

--- a/cpp2.c
+++ b/cpp2.c
@@ -631,7 +631,7 @@ ReturnCode openinclude( struct Global *global,
 
     if( filename[0] == '/' )
         {
-        if( ! openfile( global, filename ) )
+        if( ! fpp_openfile( global, filename ) )
             return(FPP_OK);
         }
 
@@ -650,7 +650,7 @@ ReturnCode openinclude( struct Global *global,
         else
             strcpy( tmpname, filename );
 
-        if( ! openfile( global, tmpname ) )
+        if( ! fpp_openfile( global, tmpname ) )
             return(FPP_OK);
         }
 
@@ -675,7 +675,7 @@ ReturnCode openinclude( struct Global *global,
             else
                 sprintf( tmpname, "%s%s", *incptr, filename );
 
-            if( !openfile( global, tmpname ) )
+            if( !fpp_openfile( global, tmpname ) )
                 return(FPP_OK);
             }
         }
@@ -742,7 +742,7 @@ ReturnCode MultiAssignLoad( struct Global *global, char *incptr, char *filename,
             //  Normally we would pass the lock and filename
             //  to the Load() routine, which would CD to the
             //  directory and Open(filename), but in order to
-            //  satisfy the exisiting openfile() function, we
+            //  satisfy the exisiting fpp_openfile() function, we
             //  bite the bullet and build the complete pathspec
             //  rather than add the standard Load() routine.
             //
@@ -750,7 +750,7 @@ ReturnCode MultiAssignLoad( struct Global *global, char *incptr, char *filename,
                 {
                 AddPart( tmpname, filename, NWORK );
 
-                RtnCode = openfile( global, tmpname );
+                RtnCode = fpp_openfile( global, tmpname );
 
                 if( ! RtnCode )
                     break;

--- a/cpp2.c
+++ b/cpp2.c
@@ -149,7 +149,7 @@ ReturnCode control( struct Global *global,
      * control keyword (or L_nogood if we think it's nonsense).
      */
     if( global->infile->fp == NULL )
-        cwarn( global, WARN_CONTROL_LINE_IN_MACRO, global->tokenbuf );
+        fpp_cwarn( global, WARN_CONTROL_LINE_IN_MACRO, global->tokenbuf );
 
     if( !compiling )
         {                       /* Not compiling now    */
@@ -160,7 +160,7 @@ ReturnCode control( struct Global *global,
             case L_ifndef:          /*   we must nest #if's */
                 if( ++global->ifptr >= &global->ifstack[BLK_NEST] )
                     {
-                    cfatal( global, FATAL_TOO_MANY_NESTINGS, global->tokenbuf );
+                    fpp_cfatal( global, FATAL_TOO_MANY_NESTINGS, global->tokenbuf );
 
                     return( FPP_TOO_MANY_NESTED_STATEMENTS );
                     }
@@ -265,7 +265,7 @@ ReturnCode control( struct Global *global,
         case L_else:
             if( global->ifptr == &global->ifstack[0] )
                 {
-                cerror( global, ERROR_STRING_MUST_BE_IF, global->tokenbuf );
+                fpp_cerror( global, ERROR_STRING_MUST_BE_IF, global->tokenbuf );
 
                 dump_line( global, counter );
 
@@ -273,7 +273,7 @@ ReturnCode control( struct Global *global,
                 }
             else if( (*global->ifptr & ELSE_SEEN) != 0 )
                 {
-                cerror( global, ERROR_STRING_MAY_NOT_FOLLOW_ELSE, global->tokenbuf );
+                fpp_cerror( global, ERROR_STRING_MAY_NOT_FOLLOW_ELSE, global->tokenbuf );
 
                 dump_line( global, counter );
 
@@ -296,7 +296,7 @@ ReturnCode control( struct Global *global,
         case L_elif:
             if( global->ifptr == &global->ifstack[0] )
                 {
-                cerror( global, ERROR_STRING_MUST_BE_IF, global->tokenbuf );
+                fpp_cerror( global, ERROR_STRING_MUST_BE_IF, global->tokenbuf );
 
                 dump_line( global, counter );
 
@@ -304,7 +304,7 @@ ReturnCode control( struct Global *global,
                 }
             else if( (*global->ifptr & ELSE_SEEN) != 0 )
                 {
-                cerror( global, ERROR_STRING_MAY_NOT_FOLLOW_ELSE, global->tokenbuf );
+                fpp_cerror( global, ERROR_STRING_MAY_NOT_FOLLOW_ELSE, global->tokenbuf );
 
                 dump_line( global, counter );
 
@@ -328,7 +328,7 @@ ReturnCode control( struct Global *global,
             break;
 
         case L_error:
-            cerror(global, ERROR_ERROR);
+            fpp_cerror(global, ERROR_ERROR);
             break;
 
         case L_if:
@@ -346,14 +346,14 @@ ReturnCode control( struct Global *global,
                 break;
                 }
 
-            cfatal( global, FATAL_TOO_MANY_NESTINGS, global->tokenbuf );
+            fpp_cfatal( global, FATAL_TOO_MANY_NESTINGS, global->tokenbuf );
 
             return( FPP_TOO_MANY_NESTED_STATEMENTS );
 
         case L_endif:
             if( global->ifptr == &global->ifstack[0] )
                 {
-                cerror( global, ERROR_STRING_MUST_BE_IF, global->tokenbuf );
+                fpp_cerror( global, ERROR_STRING_MUST_BE_IF, global->tokenbuf );
 
                 dump_line( global, counter );
 
@@ -379,7 +379,7 @@ ReturnCode control( struct Global *global,
                 return(ret);
 
             if( result == 0 )
-                cerror( global, ERROR_PREPROC_FAILURE );
+                fpp_cerror( global, ERROR_PREPROC_FAILURE );
             }
             break;
 
@@ -407,7 +407,7 @@ ReturnCode control( struct Global *global,
              * This would allow #asm or similar extensions.
              */
             if( global->warnillegalcpp )
-                cwarn( global, WARN_ILLEGAL_COMMAND, global->tokenbuf );
+                fpp_cwarn( global, WARN_ILLEGAL_COMMAND, global->tokenbuf );
 
             fpp_Putchar( global, '#' );
             fpp_Putstring( global, global->tokenbuf );
@@ -437,7 +437,7 @@ ReturnCode control( struct Global *global,
         #else
         if( skipws( global ) != '\n' )
             {
-            cwarn( global, WARN_UNEXPECTED_TEXT_IGNORED );
+            fpp_cwarn( global, WARN_UNEXPECTED_TEXT_IGNORED );
 
             skipnl( global );
             }
@@ -477,7 +477,7 @@ ReturnCode doif(struct Global *global, int hash)
         {
         fpp_unget( global );
 
-        cerror( global, ERROR_MISSING_ARGUMENT );
+        fpp_cerror( global, ERROR_MISSING_ARGUMENT );
 
         #if !OLD_PREPROCESSOR
         skipnl( global );               /* Prevent an extra     */
@@ -506,7 +506,7 @@ ReturnCode doif(struct Global *global, int hash)
         if( type[c] != LET )
             {         /* Next non-blank isn't letter  */
                           /* ... is an error          */
-            cerror( global, ERROR_MISSING_ARGUMENT );
+            fpp_cerror( global, ERROR_MISSING_ARGUMENT );
 
             #if !OLD_PREPROCESSOR
             skipnl( global );             /* Prevent an extra     */
@@ -564,7 +564,7 @@ ReturnCode doinclude( struct Global *global )
 
     if( delim != '<' && delim != '"' )
         {
-        cerror( global, ERROR_INCLUDE_SYNTAX );
+        fpp_cerror( global, ERROR_INCLUDE_SYNTAX );
 
         return( FPP_OK );
         }
@@ -589,7 +589,7 @@ ReturnCode doinclude( struct Global *global )
 
     if( *global->workp != delim )
         {
-        cerror( global, ERROR_INCLUDE_SYNTAX );
+        fpp_cerror( global, ERROR_INCLUDE_SYNTAX );
 
         return(FPP_OK);
         }
@@ -603,7 +603,7 @@ ReturnCode doinclude( struct Global *global )
         /*
          * Warn if #include file isn't there.
          */
-        cwarn( global, WARN_CANNOT_OPEN_INCLUDE, global->work );
+        fpp_cwarn( global, WARN_CANNOT_OPEN_INCLUDE, global->work );
         }
 
     return( FPP_OK );
@@ -664,7 +664,7 @@ ReturnCode openinclude( struct Global *global,
 
         if( len + strlen(filename) >= sizeof(tmpname) )
             {
-            cfatal( global, FATAL_FILENAME_BUFFER_OVERFLOW );
+            fpp_cfatal( global, FATAL_FILENAME_BUFFER_OVERFLOW );
 
             return( FPP_FILENAME_BUFFER_OVERFLOW );
             }

--- a/cpp2.c
+++ b/cpp2.c
@@ -86,7 +86,7 @@ ReturnCode control( struct Global *global,
         scanid( global, c );                  /* Get #word to tokenbuf        */
     else
         {
-        unget( global );                    /* Hack -- allow #123 as a      */
+        fpp_unget( global );                    /* Hack -- allow #123 as a      */
 
         strcpy( global->tokenbuf, "line" );   /* synonym for #line 123        */
         }
@@ -211,7 +211,7 @@ ReturnCode control( struct Global *global,
                 c = fpp_get( global );
                 }
 
-            unget( global );
+            fpp_unget( global );
 
             if( (ret = save( global, EOS )) )
                 return(ret);
@@ -393,7 +393,7 @@ ReturnCode control( struct Global *global,
             while( (c = fpp_get( global ) ) != '\n' && c != EOF_CHAR )
                 Putchar( global, c );
 
-            unget( global );
+            fpp_unget( global );
 
             Putchar( global, '\n' );
 
@@ -416,7 +416,7 @@ ReturnCode control( struct Global *global,
             while( (c = fpp_get( global ) ) != '\n' && c != EOF_CHAR )
                 Putchar( global, c );
 
-            unget( global );
+            fpp_unget( global );
 
             Putchar( global, '\n' );
 
@@ -475,14 +475,14 @@ ReturnCode doif(struct Global *global, int hash)
 
     if( (c = skipws( global ) ) == '\n' || c == EOF_CHAR )
         {
-        unget( global );
+        fpp_unget( global );
 
         cerror( global, ERROR_MISSING_ARGUMENT );
 
         #if !OLD_PREPROCESSOR
         skipnl( global );               /* Prevent an extra     */
 
-        unget( global );                /* Error message        */
+        fpp_unget( global );                /* Error message        */
         #endif
 
         return(FPP_OK);
@@ -490,7 +490,7 @@ ReturnCode doif(struct Global *global, int hash)
 
     if( hash == L_if )
         {
-        unget( global );
+        fpp_unget( global );
 
         ret = eval( global, &found );
 
@@ -511,7 +511,7 @@ ReturnCode doif(struct Global *global, int hash)
             #if !OLD_PREPROCESSOR
             skipnl( global );             /* Prevent an extra     */
 
-            unget( global );              /* Error message        */
+            fpp_unget( global );              /* Error message        */
             #endif
 
             return(FPP_OK);
@@ -578,7 +578,7 @@ ReturnCode doinclude( struct Global *global )
         if( (ret = save( global, c )) )       /* Put it away.                */
             return( ret );
 
-    unget( global );                        /* Force nl after include      */
+    fpp_unget( global );                        /* Force nl after include      */
 
     /*
      * The draft is unclear if the following should be done.

--- a/cpp2.c
+++ b/cpp2.c
@@ -373,7 +373,7 @@ ReturnCode fpp_control( struct Global *global,
             {
             int result;
 
-            ret = eval( global, &result );
+            ret = fpp_eval( global, &result );
 
             if(ret)
                 return(ret);
@@ -492,7 +492,7 @@ ReturnCode doif(struct Global *global, int hash)
         {
         fpp_unget( global );
 
-        ret = eval( global, &found );
+        ret = fpp_eval( global, &found );
 
         if( ret )
             return( ret );

--- a/cpp2.c
+++ b/cpp2.c
@@ -596,7 +596,7 @@ ReturnCode doinclude( struct Global *global )
 
     *global->workp = EOS;         /* Terminate filename       */
 
-    ret = openinclude( global, global->work, (delim == '"') );
+    ret = fpp_openinclude( global, global->work, (delim == '"') );
 
     if( ret && global->warnnoinclude )
         {
@@ -613,7 +613,7 @@ ReturnCode doinclude( struct Global *global )
 ReturnCode MultiAssignLoad( struct Global *global, char *incptr, char *filename, char *tmpname );
 #endif
 
-ReturnCode openinclude( struct Global *global,
+ReturnCode fpp_openinclude( struct Global *global,
     char *filename,     /* Input file name         */
     int searchlocal )   /* FPP_TRUE if #include "file" */
 {

--- a/cpp2.c
+++ b/cpp2.c
@@ -186,7 +186,7 @@ ReturnCode control( struct Global *global,
      */
     if( *counter > 0 && (hash == L_line || hash == L_pragma) )
         {
-        Putchar( global, '\n' );
+        fpp_Putchar( global, '\n' );
 
         (*counter)--;
         }
@@ -391,11 +391,11 @@ ReturnCode control( struct Global *global,
             Putstring( global, "#pragma " );
 
             while( (c = fpp_get( global ) ) != '\n' && c != EOF_CHAR )
-                Putchar( global, c );
+                fpp_Putchar( global, c );
 
             fpp_unget( global );
 
-            Putchar( global, '\n' );
+            fpp_Putchar( global, '\n' );
 
             break;
 
@@ -409,16 +409,16 @@ ReturnCode control( struct Global *global,
             if( global->warnillegalcpp )
                 cwarn( global, WARN_ILLEGAL_COMMAND, global->tokenbuf );
 
-            Putchar( global, '#' );
+            fpp_Putchar( global, '#' );
             Putstring( global, global->tokenbuf );
-            Putchar( global, ' ' );
+            fpp_Putchar( global, ' ' );
 
             while( (c = fpp_get( global ) ) != '\n' && c != EOF_CHAR )
-                Putchar( global, c );
+                fpp_Putchar( global, c );
 
             fpp_unget( global );
 
-            Putchar( global, '\n' );
+            fpp_Putchar( global, '\n' );
 
             break;
         }

--- a/cpp2.c
+++ b/cpp2.c
@@ -31,7 +31,7 @@ SOFTWARE.
 FILE_LOCAL void fpp_dump_line(struct Global *, int *);
 FILE_LOCAL ReturnCode fpp_doif(struct Global *, int);
 INLINE FILE_LOCAL ReturnCode fpp_doinclude(struct Global *);
-INLINE FILE_LOCAL int hasdirectory(char *, char *);
+INLINE FILE_LOCAL int fpp_hasdirectory(char *, char *);
 
 
 /*
@@ -645,7 +645,7 @@ ReturnCode fpp_openinclude( struct Global *global,
          * discarding the last pathname component of the source file
          * name then tacking on the #include argument.
          */
-        if( hasdirectory( global->infile->filename, tmpname ) )
+        if( fpp_hasdirectory( global->infile->filename, tmpname ) )
             strcat( tmpname, filename );
         else
             strcpy( tmpname, filename );
@@ -684,13 +684,13 @@ ReturnCode fpp_openinclude( struct Global *global,
 }
 
 INLINE FILE_LOCAL
-int hasdirectory( char *source,   /* Directory to examine         */
+int fpp_hasdirectory( char *source,   /* Directory to examine         */
     char *result )  /* Put directory stuff here     */
 {
     /*
      * If a device or directory is found in the source filename string, the
      * node/device/directory part of the string is copied to result and
-     * hasdirectory returns FPP_TRUE.  Else, nothing is copied and it returns FPP_FALSE.
+     * fpp_hasdirectory returns FPP_TRUE.  Else, nothing is copied and it returns FPP_FALSE.
      */
 
     char *tp2;

--- a/cpp2.c
+++ b/cpp2.c
@@ -205,7 +205,7 @@ ReturnCode fpp_control( struct Global *global,
 
             while( c != '\n' && c != EOF_CHAR )
                 {
-                if( (ret = save( global, c )) )
+                if( (ret = fpp_save( global, c )) )
                     return(ret);
 
                 c = fpp_get( global );
@@ -213,7 +213,7 @@ ReturnCode fpp_control( struct Global *global,
 
             fpp_unget( global );
 
-            if( (ret = save( global, EOS )) )
+            if( (ret = fpp_save( global, EOS )) )
                 return(ret);
 
             /*
@@ -575,7 +575,7 @@ ReturnCode doinclude( struct Global *global )
     global->workp = global->work;
 
     while( (c = fpp_get(global)) != '\n' && c != EOF_CHAR )
-        if( (ret = save( global, c )) )       /* Put it away.                */
+        if( (ret = fpp_save( global, c )) )       /* Put it away.                */
             return( ret );
 
     fpp_unget( global );                        /* Force nl after include      */

--- a/cpp2.c
+++ b/cpp2.c
@@ -55,7 +55,7 @@ INLINE FILE_LOCAL int hasdirectory(char *, char *);
 #define L_pragma    ('p' + ('a' << 1))
 #define L_undef     ('u' + ('d' << 1))
 
-ReturnCode control( struct Global *global,
+ReturnCode fpp_control( struct Global *global,
     int *counter )  /* Pending newline counter */
 {
     /*

--- a/cpp2.c
+++ b/cpp2.c
@@ -83,7 +83,7 @@ ReturnCode fpp_control( struct Global *global,
         }
 
     if( !isdigit(c) )
-        scanid( global, c );                  /* Get #word to tokenbuf        */
+        fpp_scanid( global, c );                  /* Get #word to tokenbuf        */
     else
         {
         fpp_unget( global );                    /* Hack -- allow #123 as a      */

--- a/cpp2.c
+++ b/cpp2.c
@@ -73,7 +73,7 @@ ReturnCode fpp_control( struct Global *global,
     char *ep;
     ReturnCode ret;
 
-    c = skipws( global );
+    c = fpp_skipws( global );
 
     if( c == '\n' || c == EOF_CHAR )
         {
@@ -199,7 +199,7 @@ ReturnCode fpp_control( struct Global *global,
              * field and line number for the next input line.
              * Set wrongline to force it out later.
              */
-            c = skipws( global );
+            c = fpp_skipws( global );
 
             global->workp = global->work;       /* Save name in work    */
 
@@ -435,7 +435,7 @@ ReturnCode fpp_control( struct Global *global,
 
         return( FPP_OK );
         #else
-        if( skipws( global ) != '\n' )
+        if( fpp_skipws( global ) != '\n' )
             {
             fpp_cwarn( global, WARN_UNEXPECTED_TEXT_IGNORED );
 
@@ -473,7 +473,7 @@ ReturnCode doif(struct Global *global, int hash)
     int found;
     ReturnCode ret;
 
-    if( (c = skipws( global ) ) == '\n' || c == EOF_CHAR )
+    if( (c = fpp_skipws( global ) ) == '\n' || c == EOF_CHAR )
         {
         fpp_unget( global );
 
@@ -557,7 +557,7 @@ ReturnCode doinclude( struct Global *global )
     int delim;
     ReturnCode ret;
 
-    delim = skipws( global );
+    delim = fpp_skipws( global );
 
     if( (ret = macroid( global, &delim )) )
         return(ret);

--- a/cpp2.c
+++ b/cpp2.c
@@ -253,7 +253,7 @@ ReturnCode fpp_control( struct Global *global,
             break;
 
         case L_define:
-            ret = dodefine( global );
+            ret = fpp_dodefine( global );
             if( ret )
                 return(ret);
             break;

--- a/cpp2.c
+++ b/cpp2.c
@@ -517,7 +517,7 @@ ReturnCode doif(struct Global *global, int hash)
             return(FPP_OK);
             }
 
-        found = ( lookid( global, c ) != NULL ); /* Look for it in symbol table */
+        found = ( fpp_lookid( global, c ) != NULL ); /* Look for it in symbol table */
         }
 
     if( found == (hash == L_ifdef) )

--- a/cpp3.c
+++ b/cpp3.c
@@ -320,7 +320,7 @@ ReturnCode initdefines(struct Global *global)
   }
   /*
    * The magic pre-defines (__FILE__ and __LINE__ are
-   * initialized with negative argument counts.  expand()
+   * initialized with negative argument counts.  fpp_expand()
    * notices this and calls the appropriate routine.
    * DEF_NOARGS is one greater than the first "magic" definition.
    */

--- a/cpp3.c
+++ b/cpp3.c
@@ -38,7 +38,7 @@ ReturnCode openfile(struct Global *global, char *filename)
   if ((fp = fopen(filename, "r")) == NULL)
     ret=FPP_OPEN_ERROR;
   else
-    ret=addfile(global, fp, filename);
+    ret=fpp_addfile(global, fp, filename);
 
   if(!ret && global->depends) {
 	global->depends(filename, global->userdata);
@@ -53,7 +53,7 @@ ReturnCode openfile(struct Global *global, char *filename)
   return(ret);
 }
 
-ReturnCode addfile(struct Global *global,
+ReturnCode fpp_addfile(struct Global *global,
                    FILE *fp,            /* Open file pointer */
                    char *filename)      /* Name of the file  */
 {

--- a/cpp3.c
+++ b/cpp3.c
@@ -78,10 +78,10 @@ ReturnCode fpp_addfile(struct Global *global,
   return(FPP_OK);
 }
 
-int dooptions(struct Global *global, struct fppTag *tags)
+int fpp_dooptions(struct Global *global, struct fppTag *tags)
 {
   /*
-   * dooptions is called to process command line arguments (-Detc).
+   * fpp_dooptions is called to process command line arguments (-Detc).
    * It is called only at cpp startup.
    */
   DEFBUF *dp;

--- a/cpp3.c
+++ b/cpp3.c
@@ -366,7 +366,7 @@ ReturnCode fpp_initdefines(struct Global *global)
   return(FPP_OK);
 }
 
-void deldefines(struct Global *global)
+void fpp_deldefines(struct Global *global)
 {
   /*
    * Delete the built-in #define's.

--- a/cpp3.c
+++ b/cpp3.c
@@ -153,7 +153,7 @@ int fpp_dooptions(struct Global *global, struct fppTag *tags)
         /*
          * Now, save the word and its definition.
          */
-        dp = defendel(global, symbol, FPP_FALSE);
+        dp = fpp_defendel(global, symbol, FPP_FALSE);
         if(!dp)
           return(FPP_OUT_OF_MEMORY);
         dp->repl = fpp_savestring(global, text);
@@ -231,7 +231,7 @@ int fpp_dooptions(struct Global *global, struct fppTag *tags)
       }
       break;
     case FPPTAG_UNDEFINE:
-      if (defendel(global, (char *)tags->data, FPP_TRUE) == NULL)
+      if (fpp_defendel(global, (char *)tags->data, FPP_TRUE) == NULL)
         fpp_cwarn(global, WARN_NOT_DEFINED, tags->data);
       break;
     case FPPTAG_OUTPUT_DEFINES:
@@ -310,7 +310,7 @@ ReturnCode fpp_initdefines(struct Global *global)
   if (!(global->nflag & NFLAG_BUILTIN)) {
     for (pp = global->preset; *pp != NULL; pp++) {
       if (*pp[0] != EOS) {
-        dp = defendel(global, *pp, FPP_FALSE);
+        dp = fpp_defendel(global, *pp, FPP_FALSE);
         if(!dp)
           return(FPP_OUT_OF_MEMORY);
         dp->repl = fpp_savestring(global, "1");
@@ -326,7 +326,7 @@ ReturnCode fpp_initdefines(struct Global *global)
    */
   if (!(global->nflag & NFLAG_PREDEFINE)) {
     for (pp = global->magic, i = DEF_NOARGS; *pp != NULL; pp++) {
-      dp = defendel(global, *pp, FPP_FALSE);
+      dp = fpp_defendel(global, *pp, FPP_FALSE);
       if(!dp)
         return(FPP_OUT_OF_MEMORY);
       dp->nargs = --i;
@@ -335,7 +335,7 @@ ReturnCode fpp_initdefines(struct Global *global)
     /*
      * Define __DATE__ as today's date.
      */
-    dp = defendel(global, "__DATE__", FPP_FALSE);
+    dp = fpp_defendel(global, "__DATE__", FPP_FALSE);
     tp = malloc(14);
     if(!tp || !dp)
       return(FPP_OUT_OF_MEMORY);
@@ -351,7 +351,7 @@ ReturnCode fpp_initdefines(struct Global *global)
     /*
      * Define __TIME__ as this moment's time.
      */
-    dp = defendel(global, "__TIME__", FPP_FALSE);
+    dp = fpp_defendel(global, "__TIME__", FPP_FALSE);
     tp = malloc(11);
     if(!tp || !dp)
       return(FPP_OUT_OF_MEMORY);
@@ -379,25 +379,25 @@ void deldefines(struct Global *global)
    */
   if (global->wflag < 2) {
     for (pp = global->preset; *pp != NULL; pp++) {
-      defendel(global, *pp, FPP_TRUE);
+      fpp_defendel(global, *pp, FPP_TRUE);
     }
   }
   /*
    * The magic pre-defines __FILE__ and __LINE__
    */
   for (pp = global->magic; *pp != NULL; pp++) {
-    defendel(global, *pp, FPP_TRUE);
+    fpp_defendel(global, *pp, FPP_TRUE);
   }
 #if OK_DATE
   /*
    * Undefine __DATE__.
    */
-  defendel(global, "__DATE__", FPP_TRUE);
+  fpp_defendel(global, "__DATE__", FPP_TRUE);
 
   /*
    * Undefine __TIME__.
    */
-  defendel(global, "__TIME__", FPP_TRUE);
+  fpp_defendel(global, "__TIME__", FPP_TRUE);
 #endif
   return;
 }

--- a/cpp3.c
+++ b/cpp3.c
@@ -156,7 +156,7 @@ int dooptions(struct Global *global, struct fppTag *tags)
         dp = defendel(global, symbol, FPP_FALSE);
         if(!dp)
           return(FPP_OUT_OF_MEMORY);
-        dp->repl = savestring(global, text);
+        dp->repl = fpp_savestring(global, text);
         dp->nargs = DEF_NOARGS;
       }
       break;
@@ -313,7 +313,7 @@ ReturnCode initdefines(struct Global *global)
         dp = defendel(global, *pp, FPP_FALSE);
         if(!dp)
           return(FPP_OUT_OF_MEMORY);
-        dp->repl = savestring(global, "1");
+        dp->repl = fpp_savestring(global, "1");
         dp->nargs = DEF_NOARGS;
       }
     }

--- a/cpp3.c
+++ b/cpp3.c
@@ -60,15 +60,15 @@ ReturnCode addfile(struct Global *global,
   /*
    * Initialize tables for this open file.  This is called from openfile()
    * above (for #include files), and from the entry to cpp to open the main
-   * input file. It calls a common routine, getfile() to build the FILEINFO
-   * structure which is used to read characters. (getfile() is also called
+   * input file. It calls a common routine, fpp_getfile() to build the FILEINFO
+   * structure which is used to read characters. (fpp_getfile() is also called
    * to setup a macro replacement.)
    */
 
   FILEINFO *file;
   ReturnCode ret;
 
-  ret = getfile(global, NBUFF, filename, &file);
+  ret = fpp_getfile(global, NBUFF, filename, &file);
   if(ret)
     return(ret);
   file->fp = fp;                        /* Better remember FILE *       */

--- a/cpp3.c
+++ b/cpp3.c
@@ -46,9 +46,9 @@ ReturnCode openfile(struct Global *global, char *filename)
 
   if(!ret && global->showincluded) {
           /* no error occured! */
-          Error(global, "cpp: included \"");
-          Error(global, filename);
-          Error(global, "\"\n");
+          fpp_Error(global, "cpp: included \"");
+          fpp_Error(global, filename);
+          fpp_Error(global, "\"\n");
   }
   return(ret);
 }

--- a/cpp3.c
+++ b/cpp3.c
@@ -74,7 +74,7 @@ ReturnCode addfile(struct Global *global,
   file->fp = fp;                        /* Better remember FILE *       */
   file->buffer[0] = EOS;                /* Initialize for first read    */
   global->line = 1;                     /* Working on line 1 now        */
-  global->wrongline = TRUE;             /* Force out initial #line      */
+  global->wrongline = FPP_TRUE;             /* Force out initial #line      */
   return(FPP_OK);
 }
 
@@ -85,12 +85,12 @@ int dooptions(struct Global *global, struct fppTag *tags)
    * It is called only at cpp startup.
    */
   DEFBUF *dp;
-  char end=FALSE; /* end of taglist */
+  char end=FPP_FALSE; /* end of taglist */
 
   while(tags && !end) {
     switch(tags->tag) {
     case FPPTAG_END:
-      end=TRUE;
+      end=FPP_TRUE;
       break;
     case FPPTAG_INITFUNC:
       global->initialfunc = (char *) tags->data;
@@ -133,8 +133,8 @@ int dooptions(struct Global *global, struct fppTag *tags)
       break;
     case FPPTAG_KEEPCOMMENTS:
       if(tags->data) {
-        global->cflag = TRUE;
-        global->keepcomments = TRUE;
+        global->cflag = FPP_TRUE;
+        global->keepcomments = FPP_TRUE;
       }
       break;
     case FPPTAG_DEFINE:
@@ -153,7 +153,7 @@ int dooptions(struct Global *global, struct fppTag *tags)
         /*
          * Now, save the word and its definition.
          */
-        dp = defendel(global, symbol, FALSE);
+        dp = defendel(global, symbol, FPP_FALSE);
         if(!dp)
           return(FPP_OUT_OF_MEMORY);
         dp->repl = savestring(global, text);
@@ -161,7 +161,7 @@ int dooptions(struct Global *global, struct fppTag *tags)
       }
       break;
     case FPPTAG_IGNORE_NONFATAL:
-      global->eflag = TRUE;
+      global->eflag = FPP_TRUE;
       break;
     case FPPTAG_INCLUDE_DIR:
       if (global->incend >= &global->incdir[NINCLUDE]) {
@@ -196,7 +196,7 @@ int dooptions(struct Global *global, struct fppTag *tags)
       {
         SIZES *sizp;    /* For -S               */
         int size;       /* For -S               */
-        int isdatum;    /* FALSE for -S*        */
+        int isdatum;    /* FPP_FALSE for -S*        */
         int endtest;    /* For -S               */
 
         char *text=(char *)tags->data;
@@ -231,7 +231,7 @@ int dooptions(struct Global *global, struct fppTag *tags)
       }
       break;
     case FPPTAG_UNDEFINE:
-      if (defendel(global, (char *)tags->data, TRUE) == NULL)
+      if (defendel(global, (char *)tags->data, FPP_TRUE) == NULL)
         cwarn(global, WARN_NOT_DEFINED, tags->data);
       break;
     case FPPTAG_OUTPUT_DEFINES:
@@ -310,7 +310,7 @@ ReturnCode initdefines(struct Global *global)
   if (!(global->nflag & NFLAG_BUILTIN)) {
     for (pp = global->preset; *pp != NULL; pp++) {
       if (*pp[0] != EOS) {
-        dp = defendel(global, *pp, FALSE);
+        dp = defendel(global, *pp, FPP_FALSE);
         if(!dp)
           return(FPP_OUT_OF_MEMORY);
         dp->repl = savestring(global, "1");
@@ -326,7 +326,7 @@ ReturnCode initdefines(struct Global *global)
    */
   if (!(global->nflag & NFLAG_PREDEFINE)) {
     for (pp = global->magic, i = DEF_NOARGS; *pp != NULL; pp++) {
-      dp = defendel(global, *pp, FALSE);
+      dp = defendel(global, *pp, FPP_FALSE);
       if(!dp)
         return(FPP_OUT_OF_MEMORY);
       dp->nargs = --i;
@@ -335,7 +335,7 @@ ReturnCode initdefines(struct Global *global)
     /*
      * Define __DATE__ as today's date.
      */
-    dp = defendel(global, "__DATE__", FALSE);
+    dp = defendel(global, "__DATE__", FPP_FALSE);
     tp = malloc(14);
     if(!tp || !dp)
       return(FPP_OUT_OF_MEMORY);
@@ -351,7 +351,7 @@ ReturnCode initdefines(struct Global *global)
     /*
      * Define __TIME__ as this moment's time.
      */
-    dp = defendel(global, "__TIME__", FALSE);
+    dp = defendel(global, "__TIME__", FPP_FALSE);
     tp = malloc(11);
     if(!tp || !dp)
       return(FPP_OUT_OF_MEMORY);
@@ -379,25 +379,25 @@ void deldefines(struct Global *global)
    */
   if (global->wflag < 2) {
     for (pp = global->preset; *pp != NULL; pp++) {
-      defendel(global, *pp, TRUE);
+      defendel(global, *pp, FPP_TRUE);
     }
   }
   /*
    * The magic pre-defines __FILE__ and __LINE__
    */
   for (pp = global->magic; *pp != NULL; pp++) {
-    defendel(global, *pp, TRUE);
+    defendel(global, *pp, FPP_TRUE);
   }
 #if OK_DATE
   /*
    * Undefine __DATE__.
    */
-  defendel(global, "__DATE__", TRUE);
+  defendel(global, "__DATE__", FPP_TRUE);
 
   /*
    * Undefine __TIME__.
    */
-  defendel(global, "__TIME__", TRUE);
+  defendel(global, "__TIME__", FPP_TRUE);
 #endif
   return;
 }

--- a/cpp3.c
+++ b/cpp3.c
@@ -25,11 +25,11 @@ SOFTWARE.
 #include        "cppdef.h"
 #include        "cpp.h"
 
-ReturnCode openfile(struct Global *global, char *filename)
+ReturnCode fpp_openfile(struct Global *global, char *filename)
 {
   /*
    * Open a file, add it to the linked list of open files.
-   * This is called only from openfile() in cpp2.c.
+   * This is called only from fpp_openfile() in cpp2.c.
    */
 
   FILE *fp;
@@ -58,7 +58,7 @@ ReturnCode fpp_addfile(struct Global *global,
                    char *filename)      /* Name of the file  */
 {
   /*
-   * Initialize tables for this open file.  This is called from openfile()
+   * Initialize tables for this open file.  This is called from fpp_openfile()
    * above (for #include files), and from the entry to cpp to open the main
    * input file. It calls a common routine, fpp_getfile() to build the FILEINFO
    * structure which is used to read characters. (fpp_getfile() is also called

--- a/cpp3.c
+++ b/cpp3.c
@@ -165,7 +165,7 @@ int dooptions(struct Global *global, struct fppTag *tags)
       break;
     case FPPTAG_INCLUDE_DIR:
       if (global->incend >= &global->incdir[NINCLUDE]) {
-          cfatal(global, FATAL_TOO_MANY_INCLUDE_DIRS);
+          fpp_cfatal(global, FATAL_TOO_MANY_INCLUDE_DIRS);
           return(FPP_TOO_MANY_INCLUDE_DIRS);
       }
       *global->incend++ = (char *)tags->data;
@@ -173,7 +173,7 @@ int dooptions(struct Global *global, struct fppTag *tags)
     case FPPTAG_INCLUDE_FILE:
     case FPPTAG_INCLUDE_MACRO_FILE:
       if (global->included >= NINCLUDE) {
-          cfatal(global, FATAL_TOO_MANY_INCLUDE_FILES);
+          fpp_cfatal(global, FATAL_TOO_MANY_INCLUDE_FILES);
           return(FPP_TOO_MANY_INCLUDE_FILES);
       }
       global->include[(unsigned)global->included] = (char *)tags->data;
@@ -225,14 +225,14 @@ int dooptions(struct Global *global, struct fppTag *tags)
           sizp++;
         }
         if (sizp->bits != endtest)
-          cwarn(global, WARN_TOO_FEW_VALUES_TO_SIZEOF, NULL);
+          fpp_cwarn(global, WARN_TOO_FEW_VALUES_TO_SIZEOF, NULL);
         else if (*text != EOS)
-          cwarn(global, WARN_TOO_MANY_VALUES_TO_SIZEOF, NULL);
+          fpp_cwarn(global, WARN_TOO_MANY_VALUES_TO_SIZEOF, NULL);
       }
       break;
     case FPPTAG_UNDEFINE:
       if (defendel(global, (char *)tags->data, FPP_TRUE) == NULL)
-        cwarn(global, WARN_NOT_DEFINED, tags->data);
+        fpp_cwarn(global, WARN_NOT_DEFINED, tags->data);
       break;
     case FPPTAG_OUTPUT_DEFINES:
       global->wflag++;
@@ -269,7 +269,7 @@ int dooptions(struct Global *global, struct fppTag *tags)
       global->allowincludelocal=(tags->data?1:0);
       break;
     default:
-      cwarn(global, WARN_INTERNAL_ERROR, NULL);
+      fpp_cwarn(global, WARN_INTERNAL_ERROR, NULL);
       break;
     }
     tags++;

--- a/cpp3.c
+++ b/cpp3.c
@@ -277,7 +277,7 @@ int fpp_dooptions(struct Global *global, struct fppTag *tags)
   return(0);
 }
 
-ReturnCode initdefines(struct Global *global)
+ReturnCode fpp_initdefines(struct Global *global)
 {
   /*
    * Initialize the built-in #define's.  There are two flavors:

--- a/cpp4.c
+++ b/cpp4.c
@@ -162,7 +162,7 @@ ReturnCode fpp_dodefine(struct Global *global)
 	
     case DIG:				/* Number in mac. body	*/
     case DOT:				/* Maybe a float number */
-      ret=scannumber(global, c, fpp_save);  /* Scan it off          */
+      ret=fpp_scannumber(global, c, fpp_save);  /* Scan it off          */
       if(ret)
 	return(ret);
       break;

--- a/cpp4.c
+++ b/cpp4.c
@@ -32,7 +32,7 @@ INLINE FILE_LOCAL ReturnCode expcollect(struct Global *);
 INLINE FILE_LOCAL char *doquoting(char *, char *);
 
 
-ReturnCode dodefine(struct Global *global)
+ReturnCode fpp_dodefine(struct Global *global)
 {
   /*
    * Called from control when a #define is scanned.  This module

--- a/cpp4.c
+++ b/cpp4.c
@@ -568,7 +568,7 @@ ReturnCode expstuff(struct Global *global,
   char quoting;	/* Quote macro argument */
 #endif
       
-  ret = getfile(global, NBUFF, MacroName, &file);
+  ret = fpp_getfile(global, NBUFF, MacroName, &file);
   if(ret)
     return(ret);
   inp = MacroReplace;			/* -> macro replacement */

--- a/cpp4.c
+++ b/cpp4.c
@@ -205,7 +205,7 @@ ReturnCode dodefine(struct Global *global)
     /* preceding a formal	*/
   }
   global->inmacro = FPP_FALSE;		/* Stop newline hack	*/
-  unget(global);                            /* For control check    */
+  fpp_unget(global);                            /* For control check    */
   if (global->workp > global->work && global->workp[-1] == ' ') /* Drop trailing blank  */
     global->workp--;
   *global->workp = EOS;		/* Terminate work	*/
@@ -373,7 +373,7 @@ ReturnCode expand(struct Global *global, DEFBUF *tokenp)
       do {
 	c = fpp_get(global);
       } while (global->infile != NULL && global->infile->fp == NULL);
-      unget(global);
+      fpp_unget(global);
       global->recursion = 0;
       return(FPP_OK);
     }
@@ -447,7 +447,7 @@ ReturnCode expand(struct Global *global, DEFBUF *tokenp)
        *	foo [no ()]
        * just write foo to the output stream.
        */
-      unget(global);
+      fpp_unget(global);
       cwarn(global, WARN_MACRO_NEEDS_ARGUMENTS, tokenp->name);
 
       /* fputs(tokenp->name, stdout); */
@@ -514,7 +514,7 @@ ReturnCode expcollect(struct Global *global)
 	paren++;			/* To know about commas */
       else if (c == ')') {              /* Other side too       */
 	if (paren == 0) {               /* At the end?          */
-	  unget(global);                /* Look at it later     */
+	  fpp_unget(global);                /* Look at it later     */
 	  break;			/* Exit arg getter.     */
 	}
 	paren--;			/* More to come.        */

--- a/cpp4.c
+++ b/cpp4.c
@@ -143,7 +143,7 @@ ReturnCode fpp_dodefine(struct Global *global)
       }
       while (global->workp > global->work && type[(unsigned)*(global->workp - 1)] == SPA)
 	--global->workp;		/* Erase leading spaces */
-      if((ret=save(global, TOK_SEP)))     /* Stuff a delimiter    */
+      if((ret=fpp_save(global, TOK_SEP)))     /* Stuff a delimiter    */
 	return(ret);
       c = skipws(global);               /* Eat whitespace       */
       continue;
@@ -162,7 +162,7 @@ ReturnCode fpp_dodefine(struct Global *global)
 	
     case DIG:				/* Number in mac. body	*/
     case DOT:				/* Maybe a float number */
-      ret=scannumber(global, c, save);  /* Scan it off          */
+      ret=scannumber(global, c, fpp_save);  /* Scan it off          */
       if(ret)
 	return(ret);
       break;
@@ -174,12 +174,12 @@ ReturnCode fpp_dodefine(struct Global *global)
       break;
 	
     case BSH:				/* Backslash		*/
-      ret=save(global, '\\');
+      ret=fpp_save(global, '\\');
       if(ret)
 	return(ret);
       if ((c = fpp_get(global)) == '\n')
 	global->wrongline = FPP_TRUE;
-      ret=save(global, c);
+      ret=fpp_save(global, c);
       if(ret)
 	return(ret);
       break;
@@ -195,7 +195,7 @@ ReturnCode fpp_dodefine(struct Global *global)
 	c = ' ';                      /* Normalize tabs       */
       /* Fall through to store character			*/
     default:				/* Other character	*/
-      ret=save(global, c);
+      ret=fpp_save(global, c);
       if(ret)
 	return(ret);
       break;
@@ -246,19 +246,19 @@ ReturnCode checkparm(struct Global *global,
     if (streq(global->parlist[i], global->tokenbuf)) {  /* If it's known */
 #if OK_CONCAT
       if (quoting) {                    /* Special handling of  */
-	ret=save(global, QUOTE_PARM);     /* #formal inside defn  */
+	ret=fpp_save(global, QUOTE_PARM);     /* #formal inside defn  */
 	if(ret)
 	  return(ret);
       }
 #endif
-      ret=save(global, i + MAC_PARM);     /* Save a magic cookie  */
+      ret=fpp_save(global, i + MAC_PARM);     /* Save a magic cookie  */
       return(ret);		      /* And exit the search	*/
     }
   }
   if (streq(dp->name, global->tokenbuf))    /* Macro name in body?  */
-    ret=save(global, DEF_MAGIC);            /* Save magic marker    */
-  for (cp = global->tokenbuf; *cp != EOS;)  /* And save             */
-    ret=save(global, *cp++);                /* The token itself     */
+    ret=fpp_save(global, DEF_MAGIC);            /* Save magic marker    */
+  for (cp = global->tokenbuf; *cp != EOS;)  /* And fpp_save             */
+    ret=fpp_save(global, *cp++);                /* The token itself     */
   return(ret);
 }
 
@@ -274,7 +274,7 @@ ReturnCode stparmscan(struct Global *global, int delim)
   ReturnCode ret;
       
   wp = (unsigned char *)global->workp;	/* Here's where it starts       */
-  ret=scanstring(global, delim, save);
+  ret=scanstring(global, delim, fpp_save);
   if(ret)
     return(ret);		/* Exit on scanstring error	*/
   global->workp[-1] = EOS;		/* Erase trailing quote 	*/

--- a/cpp4.c
+++ b/cpp4.c
@@ -29,7 +29,7 @@ INLINE FILE_LOCAL ReturnCode fpp_stparmscan(struct Global *, int);
 INLINE FILE_LOCAL ReturnCode fpp_textput(struct Global *, char *);
 FILE_LOCAL ReturnCode fpp_charput(struct Global *, int);
 INLINE FILE_LOCAL ReturnCode fpp_expcollect(struct Global *);
-INLINE FILE_LOCAL char *doquoting(char *, char *);
+INLINE FILE_LOCAL char *fpp_doquoting(char *, char *);
 
 
 ReturnCode fpp_dodefine(struct Global *global)
@@ -534,7 +534,7 @@ ReturnCode fpp_expcollect(struct Global *global)
 #if OK_CONCAT
   
 INLINE FILE_LOCAL
-char *doquoting(char *to, char *from)
+char *fpp_doquoting(char *to, char *from)
 {
   *to++ = '"';
   while (*from) {
@@ -611,7 +611,7 @@ ReturnCode fpp_expstuff(struct Global *global,
 	  }
 #if OK_CONCAT
 else if (quoting)
-  defp = doquoting(defp, global->parlist[c]);
+  defp = fpp_doquoting(defp, global->parlist[c]);
 #endif
 else {
   strcpy(defp, global->parlist[c]);

--- a/cpp4.c
+++ b/cpp4.c
@@ -87,7 +87,7 @@ ReturnCode fpp_dodefine(struct Global *global)
   }
   isredefine = FPP_FALSE;			/* Set if redefining	*/
   if ((dp = fpp_lookid(global, c)) == NULL) { /* If not known now     */
-    dp = defendel(global, global->tokenbuf, FPP_FALSE); /* Save the name  */
+    dp = fpp_defendel(global, global->tokenbuf, FPP_FALSE); /* Save the name  */
     if(!dp)
       return(FPP_OUT_OF_MEMORY);
   } else {				/* It's known:          */
@@ -303,7 +303,7 @@ void fpp_doundef(struct Global *global)
     fpp_cerror(global, ERROR_ILLEGAL_UNDEF);
   else {
     fpp_scanid(global, c);                         /* Get name to tokenbuf */
-    (void) defendel(global, global->tokenbuf, FPP_TRUE);
+    (void) fpp_defendel(global, global->tokenbuf, FPP_TRUE);
   }
 }
 

--- a/cpp4.c
+++ b/cpp4.c
@@ -461,7 +461,7 @@ ReturnCode fpp_expand(struct Global *global, DEFBUF *tokenp)
       return(ret); /* We failed in argument colleting! */
     }
   case DEF_NOARGS:			/* No parameters just stuffs	*/
-    ret=expstuff(global, tokenp->name, tokenp->repl); /* expand macro   */
+    ret=fpp_expstuff(global, tokenp->name, tokenp->repl); /* expand macro   */
   }					/* nargs switch 		*/
   return(ret);
 }
@@ -549,7 +549,7 @@ char *doquoting(char *to, char *from)
   
 #endif
   
-ReturnCode expstuff(struct Global *global,
+ReturnCode fpp_expstuff(struct Global *global,
 		    char *MacroName,
 		    char *MacroReplace)
 {

--- a/cpp4.c
+++ b/cpp4.c
@@ -396,7 +396,7 @@ ReturnCode expand(struct Global *global, DEFBUF *tokenp)
 		  break;
 	      }
 	  }
-      ret=ungetstring(global, global->work);
+      ret=fpp_ungetstring(global, global->work);
       if(ret)
 	  return(ret);
       break;
@@ -406,7 +406,7 @@ ReturnCode expand(struct Global *global, DEFBUF *tokenp)
       if (file->fp != NULL) {
 	sprintf(global->work, "\"%s\"", (file->progname != NULL)
 		? file->progname : file->filename);
-	ret=ungetstring(global, global->work);
+	ret=fpp_ungetstring(global, global->work);
 	if(ret)
 	  return(ret);
 	break;
@@ -417,14 +417,14 @@ ReturnCode expand(struct Global *global, DEFBUF *tokenp)
   case (-4):				/* __FUNC__ */
     sprintf(global->work, "\"%s\"", global->functionname[0]?
 	    global->functionname : "<unknown function>");
-    ret=ungetstring(global, global->work);
+    ret=fpp_ungetstring(global, global->work);
     if(ret)
 	return(ret);
     break;
 
   case (-5):                              /* __FUNC_LINE__ */
     sprintf(global->work, "%d", global->funcline);
-    ret=ungetstring(global, global->work);
+    ret=fpp_ungetstring(global, global->work);
     if(ret)
       return(ret);
     break;

--- a/cpp4.c
+++ b/cpp4.c
@@ -96,7 +96,7 @@ ReturnCode dodefine(struct Global *global)
     dp->repl = NULL;			/* No replacement now	*/
   }
   global->parlist[0] = global->parmp = global->parm; /* Setup parm buffer */
-  if ((c = get(global)) == '(') {       /* With arguments?      */
+  if ((c = fpp_get(global)) == '(') {       /* With arguments?      */
     global->nargs = 0;			/* Init formals counter */
     do {				/* Collect formal parms */
       if (global->nargs >= LASTPARM) {
@@ -137,7 +137,7 @@ ReturnCode dodefine(struct Global *global)
   while (c != EOF_CHAR && c != '\n') {  /* Compile macro body   */
 #if OK_CONCAT
     if (c == '#') {                     /* Token concatenation? */
-      if ((c = get(global)) != '#') {   /* No, not really       */
+      if ((c = fpp_get(global)) != '#') {   /* No, not really       */
 	quoting = 1;		        /* Maybe quoting op.	*/
 	continue;
       }
@@ -177,7 +177,7 @@ ReturnCode dodefine(struct Global *global)
       ret=save(global, '\\');
       if(ret)
 	return(ret);
-      if ((c = get(global)) == '\n')
+      if ((c = fpp_get(global)) == '\n')
 	global->wrongline = FPP_TRUE;
       ret=save(global, c);
       if(ret)
@@ -200,7 +200,7 @@ ReturnCode dodefine(struct Global *global)
 	return(ret);
       break;
     }
-    c = get(global);
+    c = fpp_get(global);
     quoting = 0;			/* Only when immediately*/
     /* preceding a formal	*/
   }
@@ -354,7 +354,7 @@ ReturnCode expand(struct Global *global, DEFBUF *tokenp)
    * expcollect() to parse actual parameters, checking for the correct number.
    * It then creates a "file" containing a single line containing the
    * macro with actual parameters inserted appropriately.  This is
-   * "pushed back" onto the input stream.  (When the get() routine runs
+   * "pushed back" onto the input stream.  (When the fpp_get() routine runs
    * off the end of the macro line, it will dismiss the macro itself.)
    */
   int c;
@@ -371,7 +371,7 @@ ReturnCode expand(struct Global *global, DEFBUF *tokenp)
     cerror(global, ERROR_RECURSIVE_MACRO, tokenp->name, global->macro->name);
     if (global->rec_recover) {
       do {
-	c = get(global);
+	c = fpp_get(global);
       } while (global->infile != NULL && global->infile->fp == NULL);
       unget(global);
       global->recursion = 0;

--- a/cpp4.c
+++ b/cpp4.c
@@ -494,14 +494,14 @@ ReturnCode expcollect(struct Global *global)
       return(FPP_TOO_MANY_ARGUMENTS);
     }
     global->parlist[global->nargs++] = global->parmp; /* At start of new arg */
-    for (;; c = cget(global)) {               /* Collect arg's bytes  */
+    for (;; c = fpp_cget(global)) {               /* Collect arg's bytes  */
       if (c == EOF_CHAR) {
 	cerror(global, ERROR_EOF_IN_ARGUMENT);
 	return(FPP_EOF_IN_MACRO); /* Sorry.               */
       }
       else if (c == '\\') {             /* Quote next character */
 	charput(global, c);             /* Save the \ for later */
-	charput(global, cget(global));  /* Save the next char.  */
+	charput(global, fpp_cget(global));  /* Save the next char.  */
 	continue;			/* And go get another   */
       }
       else if (type[c] == QUO) {        /* Start of string?     */

--- a/cpp4.c
+++ b/cpp4.c
@@ -24,7 +24,7 @@ SOFTWARE.
 #include	"cppdef.h"
 #include	"cpp.h"
 
-INLINE FILE_LOCAL ReturnCode checkparm(struct Global *, int, DEFBUF *, int);
+INLINE FILE_LOCAL ReturnCode fpp_checkparm(struct Global *, int, DEFBUF *, int);
 INLINE FILE_LOCAL ReturnCode stparmscan(struct Global *, int);
 INLINE FILE_LOCAL ReturnCode textput(struct Global *, char *);
 FILE_LOCAL ReturnCode charput(struct Global *, int);
@@ -61,7 +61,7 @@ ReturnCode fpp_dodefine(struct Global *global)
    * is not.
    *
    * The following subroutines are called from define():
-   * checkparm	called when a token is scanned.  It checks through the
+   * fpp_checkparm	called when a token is scanned.  It checks through the
    *		array of formal parameters.  If a match is found, the
    *		token is replaced by a control byte which will be used
    *		to locate the parameter when the macro is expanded.
@@ -152,9 +152,9 @@ ReturnCode fpp_dodefine(struct Global *global)
     switch (type[c]) {
     case LET:
 #if OK_CONCAT
-      ret=checkparm(global, c, dp, quoting);      /* Might be a formal    */
+      ret=fpp_checkparm(global, c, dp, quoting);      /* Might be a formal    */
 #else
-      ret=checkparm(c, dp);               /* Might be a formal    */
+      ret=fpp_checkparm(c, dp);               /* Might be a formal    */
 #endif
       if(ret)
 	return(ret);
@@ -224,7 +224,7 @@ ReturnCode fpp_dodefine(struct Global *global)
 }
 
 INLINE FILE_LOCAL
-ReturnCode checkparm(struct Global *global,
+ReturnCode fpp_checkparm(struct Global *global,
 		     int c,
 		     DEFBUF *dp,
 		     int quoting)	/* Preceded by a # ?	*/

--- a/cpp4.c
+++ b/cpp4.c
@@ -27,7 +27,7 @@ SOFTWARE.
 INLINE FILE_LOCAL ReturnCode fpp_checkparm(struct Global *, int, DEFBUF *, int);
 INLINE FILE_LOCAL ReturnCode fpp_stparmscan(struct Global *, int);
 INLINE FILE_LOCAL ReturnCode fpp_textput(struct Global *, char *);
-FILE_LOCAL ReturnCode charput(struct Global *, int);
+FILE_LOCAL ReturnCode fpp_charput(struct Global *, int);
 INLINE FILE_LOCAL ReturnCode expcollect(struct Global *);
 INLINE FILE_LOCAL char *doquoting(char *, char *);
 
@@ -68,7 +68,7 @@ ReturnCode fpp_dodefine(struct Global *global)
    * fpp_textput	puts a string in the macro work area (parm[]), updating
    *		parmp to point to the first free byte in parm[].
    *		fpp_textput() tests for work buffer overflow.
-   * charput	puts a single character in the macro work area (parm[])
+   * fpp_charput	puts a single character in the macro work area (parm[])
    *		in a manner analogous to fpp_textput().
    */
   int c;
@@ -328,7 +328,7 @@ ReturnCode fpp_textput(struct Global *global, char *text)
 }
 
 FILE_LOCAL
-ReturnCode charput(struct Global *global, int c)
+ReturnCode fpp_charput(struct Global *global, int c)
 {
   /*
    * Put the byte in the parm[] buffer.
@@ -500,12 +500,12 @@ ReturnCode expcollect(struct Global *global)
 	return(FPP_EOF_IN_MACRO); /* Sorry.               */
       }
       else if (c == '\\') {             /* Quote next character */
-	charput(global, c);             /* Save the \ for later */
-	charput(global, fpp_cget(global));  /* Save the next char.  */
+	fpp_charput(global, c);             /* Save the \ for later */
+	fpp_charput(global, fpp_cget(global));  /* Save the next char.  */
 	continue;			/* And go get another   */
       }
       else if (type[c] == QUO) {        /* Start of string?     */
-	ret=fpp_scanstring(global, c, (ReturnCode (*)(struct Global *, int))charput); /* Scan it off    */
+	ret=fpp_scanstring(global, c, (ReturnCode (*)(struct Global *, int))fpp_charput); /* Scan it off    */
 	if(ret)
 	  return(ret);
 	continue;			    /* Go get next char     */
@@ -523,9 +523,9 @@ ReturnCode expcollect(struct Global *global)
 	break;
       else if (c == '\n')               /* Newline inside arg?  */
 	global->wrongline = FPP_TRUE;	/* We'll need a #line   */
-      charput(global, c);               /* Store this one       */
+      fpp_charput(global, c);               /* Store this one       */
     }				        /* Collect an argument  */
-    charput(global, EOS);               /* Terminate argument   */
+    fpp_charput(global, EOS);               /* Terminate argument   */
   }				        /* Collect all args.    */
   return(FPP_OK);                       /* Normal return        */
 }

--- a/cpp4.c
+++ b/cpp4.c
@@ -233,7 +233,7 @@ ReturnCode checkparm(struct Global *global,
    * Replace this param if it's defined.  Note that the macro name is a
    * possible replacement token. We stuff DEF_MAGIC in front of the token
    * which is treated as a LETTER by the token scanner and eaten by
-   * the output routine. This prevents the macro expander from
+   * the fpp_output routine. This prevents the macro expander from
    * looping if someone writes "#define foo foo".
    */
   

--- a/cpp4.c
+++ b/cpp4.c
@@ -274,9 +274,9 @@ ReturnCode stparmscan(struct Global *global, int delim)
   ReturnCode ret;
       
   wp = (unsigned char *)global->workp;	/* Here's where it starts       */
-  ret=scanstring(global, delim, fpp_save);
+  ret=fpp_scanstring(global, delim, fpp_save);
   if(ret)
-    return(ret);		/* Exit on scanstring error	*/
+    return(ret);		/* Exit on fpp_scanstring error	*/
   global->workp[-1] = EOS;		/* Erase trailing quote 	*/
   wp++;				/* -> first string content byte */
   for (i = 0; i < global->nargs; i++) {
@@ -505,7 +505,7 @@ ReturnCode expcollect(struct Global *global)
 	continue;			/* And go get another   */
       }
       else if (type[c] == QUO) {        /* Start of string?     */
-	ret=scanstring(global, c, (ReturnCode (*)(struct Global *, int))charput); /* Scan it off    */
+	ret=fpp_scanstring(global, c, (ReturnCode (*)(struct Global *, int))charput); /* Scan it off    */
 	if(ret)
 	  return(ret);
 	continue;			    /* Go get next char     */

--- a/cpp4.c
+++ b/cpp4.c
@@ -73,7 +73,7 @@ ReturnCode dodefine(struct Global *global)
    */
   int c;
   DEFBUF *dp;	/* -> new definition	*/
-  int isredefine;	/* TRUE if redefined	*/
+  int isredefine;	/* FPP_TRUE if redefined	*/
   char *old = NULL;		/* Remember redefined	*/
   ReturnCode ret;
 #if OK_CONCAT
@@ -82,16 +82,16 @@ ReturnCode dodefine(struct Global *global)
   
   if (type[(c = skipws(global))] != LET) {
     cerror(global, ERROR_DEFINE_SYNTAX);
-    global->inmacro = FALSE;		/* Stop <newline> hack	*/
+    global->inmacro = FPP_FALSE;		/* Stop <newline> hack	*/
     return(FPP_OK);
   }
-  isredefine = FALSE;			/* Set if redefining	*/
+  isredefine = FPP_FALSE;			/* Set if redefining	*/
   if ((dp = lookid(global, c)) == NULL) { /* If not known now     */
-    dp = defendel(global, global->tokenbuf, FALSE); /* Save the name  */
+    dp = defendel(global, global->tokenbuf, FPP_FALSE); /* Save the name  */
     if(!dp)
       return(FPP_OUT_OF_MEMORY);
   } else {				/* It's known:          */
-    isredefine = TRUE;			/* Remember this fact	*/
+    isredefine = FPP_TRUE;			/* Remember this fact	*/
     old = dp->repl;			/* Remember replacement */
     dp->repl = NULL;			/* No replacement now	*/
   }
@@ -106,7 +106,7 @@ ReturnCode dodefine(struct Global *global)
 	break;			/* Got them all 	*/
       else if (type[c] != LET) {         /* Bad formal syntax    */
 	cerror(global, ERROR_DEFINE_SYNTAX);
-	global->inmacro = FALSE;		/* Stop <newline> hack	*/
+	global->inmacro = FPP_FALSE;		/* Stop <newline> hack	*/
 	return(FPP_OK);
       }
       scanid(global, c);                        /* Get the formal param */
@@ -117,7 +117,7 @@ ReturnCode dodefine(struct Global *global)
     } while ((c = skipws(global)) == ',');    /* Get another argument */
     if (c != ')') {                     /* Must end at )        */
       cerror(global, ERROR_DEFINE_SYNTAX);
-      global->inmacro = FALSE;		/* Stop <newline> hack	*/
+      global->inmacro = FPP_FALSE;		/* Stop <newline> hack	*/
       return(FPP_OK);
     }
     c = ' ';                            /* Will skip to body    */
@@ -132,7 +132,7 @@ ReturnCode dodefine(struct Global *global)
   if (type[c] == SPA)                   /* At whitespace?       */
     c = skipws(global);                 /* Not any more.        */
   global->workp = global->work;		/* Replacement put here */
-  global->inmacro = TRUE;		/* Keep \<newline> now	*/
+  global->inmacro = FPP_TRUE;		/* Keep \<newline> now	*/
   quoting = 0;				/* No # seen yet.	*/
   while (c != EOF_CHAR && c != '\n') {  /* Compile macro body   */
 #if OK_CONCAT
@@ -178,7 +178,7 @@ ReturnCode dodefine(struct Global *global)
       if(ret)
 	return(ret);
       if ((c = get(global)) == '\n')
-	global->wrongline = TRUE;
+	global->wrongline = FPP_TRUE;
       ret=save(global, c);
       if(ret)
 	return(ret);
@@ -204,7 +204,7 @@ ReturnCode dodefine(struct Global *global)
     quoting = 0;			/* Only when immediately*/
     /* preceding a formal	*/
   }
-  global->inmacro = FALSE;		/* Stop newline hack	*/
+  global->inmacro = FPP_FALSE;		/* Stop newline hack	*/
   unget(global);                            /* For control check    */
   if (global->workp > global->work && global->workp[-1] == ' ') /* Drop trailing blank  */
     global->workp--;
@@ -303,7 +303,7 @@ void doundef(struct Global *global)
     cerror(global, ERROR_ILLEGAL_UNDEF);
   else {
     scanid(global, c);                         /* Get name to tokenbuf */
-    (void) defendel(global, global->tokenbuf, TRUE);
+    (void) defendel(global, global->tokenbuf, FPP_TRUE);
   }
 }
 
@@ -438,7 +438,7 @@ ReturnCode expand(struct Global *global, DEFBUF *tokenp)
       return(FPP_ILLEGAL_MACRO);
     }
     while ((c = skipws(global)) == '\n')      /* Look for (, skipping */
-      global->wrongline = TRUE;		/* spaces and newlines	*/
+      global->wrongline = FPP_TRUE;		/* spaces and newlines	*/
     if (c != '(') {
       /*
        * If the programmer writes
@@ -480,7 +480,7 @@ ReturnCode expcollect(struct Global *global)
   for (;;) {
     paren = 0;			    /* Collect next arg.    */
     while ((c = skipws(global)) == '\n')/* Skip over whitespace */
-      global->wrongline = TRUE;		/* and newlines.	*/
+      global->wrongline = FPP_TRUE;		/* and newlines.	*/
     if (c == ')') {                     /* At end of all args?  */
       /*
        * Note that there is a guard byte in parm[]
@@ -522,7 +522,7 @@ ReturnCode expcollect(struct Global *global)
       else if (c == ',' && paren == 0)  /* Comma delimits args  */
 	break;
       else if (c == '\n')               /* Newline inside arg?  */
-	global->wrongline = TRUE;	/* We'll need a #line   */
+	global->wrongline = FPP_TRUE;	/* We'll need a #line   */
       charput(global, c);               /* Store this one       */
     }				        /* Collect an argument  */
     charput(global, EOS);               /* Terminate argument   */

--- a/cpp4.c
+++ b/cpp4.c
@@ -86,7 +86,7 @@ ReturnCode fpp_dodefine(struct Global *global)
     return(FPP_OK);
   }
   isredefine = FPP_FALSE;			/* Set if redefining	*/
-  if ((dp = lookid(global, c)) == NULL) { /* If not known now     */
+  if ((dp = fpp_lookid(global, c)) == NULL) { /* If not known now     */
     dp = defendel(global, global->tokenbuf, FPP_FALSE); /* Save the name  */
     if(!dp)
       return(FPP_OUT_OF_MEMORY);

--- a/cpp4.c
+++ b/cpp4.c
@@ -109,7 +109,7 @@ ReturnCode fpp_dodefine(struct Global *global)
 	global->inmacro = FPP_FALSE;		/* Stop <newline> hack	*/
 	return(FPP_OK);
       }
-      scanid(global, c);                        /* Get the formal param */
+      fpp_scanid(global, c);                        /* Get the formal param */
       global->parlist[global->nargs++] = global->parmp; /* Save its start */
       ret=textput(global, global->tokenbuf); /* Save text in parm[]  */
       if(ret)
@@ -241,7 +241,7 @@ ReturnCode checkparm(struct Global *global,
   char *cp;
   ReturnCode ret=FPP_OK;
       
-  scanid(global, c);                /* Get parm to tokenbuf */
+  fpp_scanid(global, c);                /* Get parm to tokenbuf */
   for (i = 0; i < global->nargs; i++) {     /* For each argument    */
     if (streq(global->parlist[i], global->tokenbuf)) {  /* If it's known */
 #if OK_CONCAT
@@ -302,7 +302,7 @@ void fpp_doundef(struct Global *global)
   if (type[(c = skipws(global))] != LET)
     fpp_cerror(global, ERROR_ILLEGAL_UNDEF);
   else {
-    scanid(global, c);                         /* Get name to tokenbuf */
+    fpp_scanid(global, c);                         /* Get name to tokenbuf */
     (void) defendel(global, global->tokenbuf, FPP_TRUE);
   }
 }

--- a/cpp4.c
+++ b/cpp4.c
@@ -350,7 +350,7 @@ ReturnCode fpp_expand(struct Global *global, DEFBUF *tokenp)
 {
   /*
    * Expand a macro.  Called from the cpp mainline routine (via subroutine
-   * macroid()) when a token is found in the symbol table.  It calls
+   * fpp_macroid()) when a token is found in the symbol table.  It calls
    * expcollect() to parse actual parameters, checking for the correct number.
    * It then creates a "file" containing a single line containing the
    * macro with actual parameters inserted appropriately.  This is

--- a/cpp4.c
+++ b/cpp4.c
@@ -28,7 +28,7 @@ INLINE FILE_LOCAL ReturnCode fpp_checkparm(struct Global *, int, DEFBUF *, int);
 INLINE FILE_LOCAL ReturnCode fpp_stparmscan(struct Global *, int);
 INLINE FILE_LOCAL ReturnCode fpp_textput(struct Global *, char *);
 FILE_LOCAL ReturnCode fpp_charput(struct Global *, int);
-INLINE FILE_LOCAL ReturnCode expcollect(struct Global *);
+INLINE FILE_LOCAL ReturnCode fpp_expcollect(struct Global *);
 INLINE FILE_LOCAL char *doquoting(char *, char *);
 
 
@@ -351,7 +351,7 @@ ReturnCode fpp_expand(struct Global *global, DEFBUF *tokenp)
   /*
    * Expand a macro.  Called from the cpp mainline routine (via subroutine
    * fpp_macroid()) when a token is found in the symbol table.  It calls
-   * expcollect() to parse actual parameters, checking for the correct number.
+   * fpp_expcollect() to parse actual parameters, checking for the correct number.
    * It then creates a "file" containing a single line containing the
    * macro with actual parameters inserted appropriately.  This is
    * "pushed back" onto the input stream.  (When the fpp_get() routine runs
@@ -453,7 +453,7 @@ ReturnCode fpp_expand(struct Global *global, DEFBUF *tokenp)
       /* fputs(tokenp->name, stdout); */
       fpp_Putstring(global, tokenp->name);
       return(FPP_OK);
-    } else if (!(ret=expcollect(global))) {     /* Collect arguments    */
+    } else if (!(ret=fpp_expcollect(global))) {     /* Collect arguments    */
       if (tokenp->nargs != global->nargs) {     /* Should be an error?  */
 	fpp_cwarn(global, WARN_WRONG_NUMBER_ARGUMENTS, tokenp->name);
       }
@@ -467,7 +467,7 @@ ReturnCode fpp_expand(struct Global *global, DEFBUF *tokenp)
 }
 
 INLINE FILE_LOCAL
-ReturnCode expcollect(struct Global *global)
+ReturnCode fpp_expcollect(struct Global *global)
 {
   /*
    * Collect the actual parameters for this macro.

--- a/cpp4.c
+++ b/cpp4.c
@@ -451,7 +451,7 @@ ReturnCode expand(struct Global *global, DEFBUF *tokenp)
       cwarn(global, WARN_MACRO_NEEDS_ARGUMENTS, tokenp->name);
 
       /* fputs(tokenp->name, stdout); */
-      Putstring(global, tokenp->name);
+      fpp_Putstring(global, tokenp->name);
       return(FPP_OK);
     } else if (!(ret=expcollect(global))) {     /* Collect arguments    */
       if (tokenp->nargs != global->nargs) {     /* Should be an error?  */

--- a/cpp4.c
+++ b/cpp4.c
@@ -25,7 +25,7 @@ SOFTWARE.
 #include	"cpp.h"
 
 INLINE FILE_LOCAL ReturnCode fpp_checkparm(struct Global *, int, DEFBUF *, int);
-INLINE FILE_LOCAL ReturnCode stparmscan(struct Global *, int);
+INLINE FILE_LOCAL ReturnCode fpp_stparmscan(struct Global *, int);
 INLINE FILE_LOCAL ReturnCode textput(struct Global *, char *);
 FILE_LOCAL ReturnCode charput(struct Global *, int);
 INLINE FILE_LOCAL ReturnCode expcollect(struct Global *);
@@ -168,7 +168,7 @@ ReturnCode fpp_dodefine(struct Global *global)
       break;
 	
     case QUO:				/* String in mac. body	*/
-      ret=stparmscan(global, c);
+      ret=fpp_stparmscan(global, c);
       if(ret)
 	return(ret);
       break;
@@ -263,7 +263,7 @@ ReturnCode fpp_checkparm(struct Global *global,
 }
 
 INLINE FILE_LOCAL
-ReturnCode stparmscan(struct Global *global, int delim)
+ReturnCode fpp_stparmscan(struct Global *global, int delim)
 {
   /*
    * Normal string parameter scan.

--- a/cpp4.c
+++ b/cpp4.c
@@ -26,7 +26,7 @@ SOFTWARE.
 
 INLINE FILE_LOCAL ReturnCode fpp_checkparm(struct Global *, int, DEFBUF *, int);
 INLINE FILE_LOCAL ReturnCode fpp_stparmscan(struct Global *, int);
-INLINE FILE_LOCAL ReturnCode textput(struct Global *, char *);
+INLINE FILE_LOCAL ReturnCode fpp_textput(struct Global *, char *);
 FILE_LOCAL ReturnCode charput(struct Global *, int);
 INLINE FILE_LOCAL ReturnCode expcollect(struct Global *);
 INLINE FILE_LOCAL char *doquoting(char *, char *);
@@ -65,11 +65,11 @@ ReturnCode fpp_dodefine(struct Global *global)
    *		array of formal parameters.  If a match is found, the
    *		token is replaced by a control byte which will be used
    *		to locate the parameter when the macro is expanded.
-   * textput	puts a string in the macro work area (parm[]), updating
+   * fpp_textput	puts a string in the macro work area (parm[]), updating
    *		parmp to point to the first free byte in parm[].
-   *		textput() tests for work buffer overflow.
+   *		fpp_textput() tests for work buffer overflow.
    * charput	puts a single character in the macro work area (parm[])
-   *		in a manner analogous to textput().
+   *		in a manner analogous to fpp_textput().
    */
   int c;
   DEFBUF *dp;	/* -> new definition	*/
@@ -111,7 +111,7 @@ ReturnCode fpp_dodefine(struct Global *global)
       }
       fpp_scanid(global, c);                        /* Get the formal param */
       global->parlist[global->nargs++] = global->parmp; /* Save its start */
-      ret=textput(global, global->tokenbuf); /* Save text in parm[]  */
+      ret=fpp_textput(global, global->tokenbuf); /* Save text in parm[]  */
       if(ret)
 	return(ret);
     } while ((c = fpp_skipws(global)) == ',');    /* Get another argument */
@@ -308,7 +308,7 @@ void fpp_doundef(struct Global *global)
 }
 
 INLINE FILE_LOCAL  
-ReturnCode textput(struct Global *global, char *text)
+ReturnCode fpp_textput(struct Global *global, char *text)
 {
   /*
    * Put the string in the parm[] buffer.

--- a/cpp4.c
+++ b/cpp4.c
@@ -80,7 +80,7 @@ ReturnCode fpp_dodefine(struct Global *global)
   int quoting;	/* Remember we saw a #	*/
 #endif
   
-  if (type[(c = skipws(global))] != LET) {
+  if (type[(c = fpp_skipws(global))] != LET) {
     fpp_cerror(global, ERROR_DEFINE_SYNTAX);
     global->inmacro = FPP_FALSE;		/* Stop <newline> hack	*/
     return(FPP_OK);
@@ -102,7 +102,7 @@ ReturnCode fpp_dodefine(struct Global *global)
       if (global->nargs >= LASTPARM) {
 	fpp_cfatal(global, FATAL_TOO_MANY_ARGUMENTS_MACRO);
 	return(FPP_TOO_MANY_ARGUMENTS);
-      } else if ((c = skipws(global)) == ')')
+      } else if ((c = fpp_skipws(global)) == ')')
 	break;			/* Got them all 	*/
       else if (type[c] != LET) {         /* Bad formal syntax    */
 	fpp_cerror(global, ERROR_DEFINE_SYNTAX);
@@ -114,7 +114,7 @@ ReturnCode fpp_dodefine(struct Global *global)
       ret=textput(global, global->tokenbuf); /* Save text in parm[]  */
       if(ret)
 	return(ret);
-    } while ((c = skipws(global)) == ',');    /* Get another argument */
+    } while ((c = fpp_skipws(global)) == ',');    /* Get another argument */
     if (c != ')') {                     /* Must end at )        */
       fpp_cerror(global, ERROR_DEFINE_SYNTAX);
       global->inmacro = FPP_FALSE;		/* Stop <newline> hack	*/
@@ -130,7 +130,7 @@ ReturnCode fpp_dodefine(struct Global *global)
     global->nargs = DEF_NOARGS;		/* No () parameters     */
   }
   if (type[c] == SPA)                   /* At whitespace?       */
-    c = skipws(global);                 /* Not any more.        */
+    c = fpp_skipws(global);                 /* Not any more.        */
   global->workp = global->work;		/* Replacement put here */
   global->inmacro = FPP_TRUE;		/* Keep \<newline> now	*/
   quoting = 0;				/* No # seen yet.	*/
@@ -145,7 +145,7 @@ ReturnCode fpp_dodefine(struct Global *global)
 	--global->workp;		/* Erase leading spaces */
       if((ret=fpp_save(global, TOK_SEP)))     /* Stuff a delimiter    */
 	return(ret);
-      c = skipws(global);               /* Eat whitespace       */
+      c = fpp_skipws(global);               /* Eat whitespace       */
       continue;
     }
 #endif
@@ -299,7 +299,7 @@ void fpp_doundef(struct Global *global)
    */
 {
   int c;
-  if (type[(c = skipws(global))] != LET)
+  if (type[(c = fpp_skipws(global))] != LET)
     fpp_cerror(global, ERROR_ILLEGAL_UNDEF);
   else {
     fpp_scanid(global, c);                         /* Get name to tokenbuf */
@@ -437,7 +437,7 @@ ReturnCode fpp_expand(struct Global *global, DEFBUF *tokenp)
       fpp_cfatal(global, FATAL_ILLEGAL_MACRO, tokenp->name);
       return(FPP_ILLEGAL_MACRO);
     }
-    while ((c = skipws(global)) == '\n')      /* Look for (, skipping */
+    while ((c = fpp_skipws(global)) == '\n')      /* Look for (, skipping */
       global->wrongline = FPP_TRUE;		/* spaces and newlines	*/
     if (c != '(') {
       /*
@@ -479,7 +479,7 @@ ReturnCode expcollect(struct Global *global)
       
   for (;;) {
     paren = 0;			    /* Collect next arg.    */
-    while ((c = skipws(global)) == '\n')/* Skip over whitespace */
+    while ((c = fpp_skipws(global)) == '\n')/* Skip over whitespace */
       global->wrongline = FPP_TRUE;		/* and newlines.	*/
     if (c == ')') {                     /* At end of all args?  */
       /*

--- a/cpp4.c
+++ b/cpp4.c
@@ -346,7 +346,7 @@ ReturnCode charput(struct Global *global, int c)
  *		M a c r o   E x p a n s i o n
  */
 
-ReturnCode expand(struct Global *global, DEFBUF *tokenp)
+ReturnCode fpp_expand(struct Global *global, DEFBUF *tokenp)
 {
   /*
    * Expand a macro.  Called from the cpp mainline routine (via subroutine

--- a/cpp4.c
+++ b/cpp4.c
@@ -209,7 +209,7 @@ ReturnCode dodefine(struct Global *global)
   if (global->workp > global->work && global->workp[-1] == ' ') /* Drop trailing blank  */
     global->workp--;
   *global->workp = EOS;		/* Terminate work	*/
-  dp->repl = savestring(global, global->work); /* Save the string      */
+  dp->repl = fpp_savestring(global, global->work); /* Save the string      */
   dp->nargs = global->nargs;			/* Save arg count	*/
   if (isredefine) {                   /* Error if redefined   */
     if ((old != NULL && dp->repl != NULL && !streq(old, dp->repl))

--- a/cpp4.c
+++ b/cpp4.c
@@ -292,7 +292,7 @@ ReturnCode stparmscan(struct Global *global, int delim)
   return(FPP_OK);
 }
   
-void doundef(struct Global *global)
+void fpp_doundef(struct Global *global)
   /*
    * Remove the symbol from the defined list.
    * Called from the #control processor.

--- a/cpp5.c
+++ b/cpp5.c
@@ -25,7 +25,7 @@ SOFTWARE.
 #include "cpp.h"
 
 INLINE FILE_LOCAL ReturnCode fpp_evallex(struct Global *, int, int *);
-INLINE FILE_LOCAL ReturnCode dosizeof(struct Global *, int *);
+INLINE FILE_LOCAL ReturnCode fpp_dosizeof(struct Global *, int *);
 INLINE FILE_LOCAL int bittest(int);
 INLINE FILE_LOCAL int fpp_evalnum(struct Global *, int);
 INLINE FILE_LOCAL int fpp_evalchar(struct Global *, int);
@@ -439,7 +439,7 @@ ReturnCode fpp_evallex(struct Global *global,
       }
 #if OK_SIZEOF
 else if (streq(global->tokenbuf, "sizeof")) { /* New sizeof hackery   */
-  ret=dosizeof(global, op);             /* Gets own routine     */
+  ret=fpp_dosizeof(global, op);             /* Gets own routine     */
   return(ret);
 }
 #endif
@@ -510,7 +510,7 @@ else if (streq(global->tokenbuf, "sizeof")) { /* New sizeof hackery   */
 #if OK_SIZEOF
 
 INLINE FILE_LOCAL
-ReturnCode dosizeof(struct Global *global, int *result)
+ReturnCode fpp_dosizeof(struct Global *global, int *result)
 {
   /*
    * Process the sizeof (basic type) operation in an #if string.

--- a/cpp5.c
+++ b/cpp5.c
@@ -220,7 +220,7 @@ ReturnCode eval(struct Global *global, int *eval)
 {
   /*
    * Evaluate an expression.  Straight-forward operator precedence.
-   * This is called from control() on encountering an #if statement.
+   * This is called from fpp_control() on encountering an #if statement.
    * It calls the following routines:
    * evallex	Lexical analyser -- returns the type and value of
    *		the next input token.

--- a/cpp5.c
+++ b/cpp5.c
@@ -394,7 +394,7 @@ ReturnCode fpp_evallex(struct Global *global,
     loop=FPP_FALSE;
     do {					/* Collect the token	*/
       c = fpp_skipws(global);
-      if((ret=macroid(global, &c)))
+      if((ret=fpp_macroid(global, &c)))
       return(ret);
       if (c == EOF_CHAR || c == '\n') {
 	fpp_unget(global);
@@ -535,7 +535,7 @@ ReturnCode dosizeof(struct Global *global, int *result)
    */
   typecode = 0;
   while ((c = fpp_skipws(global))) {
-    if((ret=macroid(global, &c)))
+    if((ret=fpp_macroid(global, &c)))
       return(ret);
     /* (I) return on fail! */
     if (c  == EOF_CHAR || c == '\n') {

--- a/cpp5.c
+++ b/cpp5.c
@@ -742,7 +742,7 @@ int evalchar(struct Global *global,
     case 'x':                           /* '\xFF'               */
       count = 3;
       value = 0;
-      while ((((c = get(global)) >= '0' && c <= '9')
+      while ((((c = fpp_get(global)) >= '0' && c <= '9')
 	      || (c >= 'a' && c <= 'f')
 	      || (c >= 'A' && c <= 'F'))
 	     && (--count >= 0)) {
@@ -759,7 +759,7 @@ int evalchar(struct Global *global,
 	while (c >= '0' && c <= '7' && --count >= 0) {
 	  value *= 8;
 	  value += (c - '0');
-	  c = get(global);
+	  c = fpp_get(global);
 	}
 	unget(global);
       } else
@@ -776,7 +776,7 @@ int evalchar(struct Global *global,
 #if BIG_ENDIAN
   count = 0;
 #endif
-  while ((c = get(global)) != '\'' && c != EOF_CHAR && c != '\n') {
+  while ((c = fpp_get(global)) != '\'' && c != EOF_CHAR && c != '\n') {
     if (!skip)
       cwarn(global, WARN_MULTIBYTE_NOT_PORTABLE, c);
 #if BIG_ENDIAN

--- a/cpp5.c
+++ b/cpp5.c
@@ -393,7 +393,7 @@ ReturnCode fpp_evallex(struct Global *global,
   /* again: */
     loop=FPP_FALSE;
     do {					/* Collect the token	*/
-      c = skipws(global);
+      c = fpp_skipws(global);
       if((ret=macroid(global, &c)))
       return(ret);
       if (c == EOF_CHAR || c == '\n') {
@@ -423,13 +423,13 @@ ReturnCode fpp_evallex(struct Global *global,
       return(FPP_CANT_USE_STRING_IN_IF);
     } else if (t == LET) {                  /* ID must be a macro   */
       if (streq(global->tokenbuf, "defined")) {   /* Or defined name      */
-	c1 = c = skipws(global);
+	c1 = c = fpp_skipws(global);
 	if (c == '(')                     /* Allow defined(name)  */
-	  c = skipws(global);
+	  c = fpp_skipws(global);
 	if (type[c] == LET) {
 	  global->evalue = (lookid(global, c) != NULL);
 	  if (c1 != '('                   /* Need to balance      */
-	      || skipws(global) == ')') { /* Did we balance?      */
+	      || fpp_skipws(global) == ')') { /* Did we balance?      */
 	    *op=DIG;
 	    return(FPP_OK);               /* Parsed ok            */
 	  }
@@ -525,7 +525,7 @@ ReturnCode dosizeof(struct Global *global, int *result)
   short typecode;
   ReturnCode ret;
   
-  if ((c = skipws(global)) != '(') {
+  if ((c = fpp_skipws(global)) != '(') {
     fpp_unget(global);
     fpp_cerror(global, ERROR_SIZEOF_SYNTAX);
     return(FPP_SIZEOF_ERROR);
@@ -534,7 +534,7 @@ ReturnCode dosizeof(struct Global *global, int *result)
    * Scan off the tokens.
    */
   typecode = 0;
-  while ((c = skipws(global))) {
+  while ((c = fpp_skipws(global))) {
     if((ret=macroid(global, &c)))
       return(ret);
     /* (I) return on fail! */
@@ -544,11 +544,11 @@ ReturnCode dosizeof(struct Global *global, int *result)
       fpp_cerror(global, ERROR_SIZEOF_SYNTAX);
       return(FPP_SIZEOF_ERROR);
     } else if (c == '(') {                /* thing (*)() func ptr */
-      if (skipws(global) == '*'
-	  && skipws(global) == ')') {         /* We found (*)         */
-	if (skipws(global) != '(')            /* Let () be optional   */
+      if (fpp_skipws(global) == '*'
+	  && fpp_skipws(global) == ')') {         /* We found (*)         */
+	if (fpp_skipws(global) != '(')            /* Let () be optional   */
 	  fpp_unget(global);
-	else if (skipws(global) != ')') {
+	else if (fpp_skipws(global) != ')') {
 	  fpp_unget(global);
 	  fpp_cerror(global, ERROR_SIZEOF_SYNTAX);
 	  return(FPP_SIZEOF_ERROR);
@@ -586,7 +586,7 @@ ReturnCode dosizeof(struct Global *global, int *result)
    */
   if (c == '*') {
     typecode |= T_PTR;
-    c = skipws(global);
+    c = fpp_skipws(global);
   }
   if (c == ')') {                         /* Last syntax check    */
     for (testp = test_table; *testp != 0; testp++) {

--- a/cpp5.c
+++ b/cpp5.c
@@ -263,11 +263,11 @@ ReturnCode eval(struct Global *global, int *eval)
     }
     if (op == DIG) {                      /* Value?               */
       if (binop != 0) {
-	cerror(global, ERROR_MISPLACED_CONSTANT);
+	fpp_cerror(global, ERROR_MISPLACED_CONSTANT);
 	*eval=1;
 	return(FPP_OK);
       } else if (valp >= &value[NEXP-1]) {
-	cerror(global, ERROR_IF_OVERFLOW);
+	fpp_cerror(global, ERROR_IF_OVERFLOW);
 	*eval=1;
 	return(FPP_OK);
       } else {
@@ -277,13 +277,13 @@ ReturnCode eval(struct Global *global, int *eval)
       again=FPP_TRUE;
       continue;
     } else if (op > OP_END) {
-      cerror(global, ERROR_ILLEGAL_IF_LINE);
+      fpp_cerror(global, ERROR_ILLEGAL_IF_LINE);
       *eval=1;
       return(FPP_OK);
     }
     prec = opdope[op];
     if (binop != (prec & 1)) {
-      cerror(global, ERROR_OPERATOR, opname[op]);
+      fpp_cerror(global, ERROR_OPERATOR, opname[op]);
       *eval=1;
       return(FPP_OK);
     }
@@ -300,7 +300,7 @@ ReturnCode eval(struct Global *global, int *eval)
 	 */
 	opp++;
 	if (opp >= &opstack[NEXP]) {
-	  cerror(global, ERROR_EXPR_OVERFLOW, opname[op]);
+	  fpp_cerror(global, ERROR_EXPR_OVERFLOW, opname[op]);
 	  *eval=1;
 	  return(FPP_OK);
 	}
@@ -342,7 +342,7 @@ ReturnCode eval(struct Global *global, int *eval)
 	continue;
       case OP_LPA:			/* ( on stack           */
 	if (op != OP_RPA) {             /* Matches ) on input   */
-	  cerror(global, ERROR_UNBALANCED_PARENS, opname[op]);
+	  fpp_cerror(global, ERROR_UNBALANCED_PARENS, opname[op]);
 	  *eval=1;
 	  return(FPP_OK);
 	}
@@ -355,7 +355,7 @@ ReturnCode eval(struct Global *global, int *eval)
       case OP_COL:			/* : on stack.		*/
 	opp--;				/* Unstack :		*/
 	if (opp->op != OP_QUE) {        /* Matches ? on stack?  */
-	  cerror(global, ERROR_MISPLACED, opname[(unsigned)opp->op]);
+	  fpp_cerror(global, ERROR_MISPLACED, opname[(unsigned)opp->op]);
 	  *eval=1;
 	  return(FPP_OK);
 	}
@@ -408,9 +408,9 @@ ReturnCode evallex(struct Global *global,
     if (t == INV) {                         /* Total nonsense       */
       if (!skip) {
 	if (isascii(c) && isprint(c))
-	  cerror(global, ERROR_ILLEGAL_CHARACTER, c);
+	  fpp_cerror(global, ERROR_ILLEGAL_CHARACTER, c);
 	else
-	  cerror(global, ERROR_ILLEGAL_CHARACTER2, c);
+	  fpp_cerror(global, ERROR_ILLEGAL_CHARACTER2, c);
       }
       return(FPP_ILLEGAL_CHARACTER);
     } else if (t == QUO) {                  /* ' or "               */
@@ -419,7 +419,7 @@ ReturnCode evallex(struct Global *global,
 	*op=DIG;                          /* Return a value       */
 	return(FPP_OK);
       }
-      cerror(global, ERROR_STRING_IN_IF);
+      fpp_cerror(global, ERROR_STRING_IN_IF);
       return(FPP_CANT_USE_STRING_IN_IF);
     } else if (t == LET) {                  /* ID must be a macro   */
       if (streq(global->tokenbuf, "defined")) {   /* Or defined name      */
@@ -434,7 +434,7 @@ ReturnCode evallex(struct Global *global,
 	    return(FPP_OK);               /* Parsed ok            */
 	  }
 	}
-	cerror(global, ERROR_DEFINED_SYNTAX);
+	fpp_cerror(global, ERROR_DEFINED_SYNTAX);
 	return(FPP_BAD_IF_DEFINED_SYNTAX);
       }
 #if OK_SIZEOF
@@ -466,7 +466,7 @@ else if (streq(global->tokenbuf, "sizeof")) { /* New sizeof hackery   */
       case '=':
 	if (c1 != '=') {                  /* Can't say a=b in #if */
 	  fpp_unget(global);
-	  cerror(global, ERROR_ILLEGAL_ASSIGN);
+	  fpp_cerror(global, ERROR_ILLEGAL_ASSIGN);
 	  return (FPP_IF_ERROR);
 	}
 	*op=OP_EQ;
@@ -496,7 +496,7 @@ else if (streq(global->tokenbuf, "sizeof")) { /* New sizeof hackery   */
 	  loop=FPP_TRUE;
 	  break;
 	}
-	cerror(global, ERROR_ILLEGAL_BACKSLASH);
+	fpp_cerror(global, ERROR_ILLEGAL_BACKSLASH);
 	return(FPP_IF_ERROR);
       }
       if(!loop)
@@ -527,7 +527,7 @@ ReturnCode dosizeof(struct Global *global, int *result)
   
   if ((c = skipws(global)) != '(') {
     fpp_unget(global);
-    cerror(global, ERROR_SIZEOF_SYNTAX);
+    fpp_cerror(global, ERROR_SIZEOF_SYNTAX);
     return(FPP_SIZEOF_ERROR);
   }
   /*
@@ -541,7 +541,7 @@ ReturnCode dosizeof(struct Global *global, int *result)
     if (c  == EOF_CHAR || c == '\n') {
       /* End of line is a bug */
       fpp_unget(global);
-      cerror(global, ERROR_SIZEOF_SYNTAX);
+      fpp_cerror(global, ERROR_SIZEOF_SYNTAX);
       return(FPP_SIZEOF_ERROR);
     } else if (c == '(') {                /* thing (*)() func ptr */
       if (skipws(global) == '*'
@@ -550,13 +550,13 @@ ReturnCode dosizeof(struct Global *global, int *result)
 	  fpp_unget(global);
 	else if (skipws(global) != ')') {
 	  fpp_unget(global);
-	  cerror(global, ERROR_SIZEOF_SYNTAX);
+	  fpp_cerror(global, ERROR_SIZEOF_SYNTAX);
 	  return(FPP_SIZEOF_ERROR);
 	}
 	typecode |= T_FPTR; 		/* Function pointer	*/
       } else {				/* Junk is a bug	*/
 	fpp_unget(global);
-	cerror(global, ERROR_SIZEOF_SYNTAX);
+	fpp_cerror(global, ERROR_SIZEOF_SYNTAX);
 	return(FPP_SIZEOF_ERROR);
       }
     }
@@ -574,7 +574,7 @@ ReturnCode dosizeof(struct Global *global, int *result)
 	  break;
       }
       if (tp->name == NULLST) {
-	cerror(global, ERROR_SIZEOF_UNKNOWN, global->tokenbuf);
+	fpp_cerror(global, ERROR_SIZEOF_UNKNOWN, global->tokenbuf);
 	return(FPP_SIZEOF_ERROR);
       }
       typecode |= tp->type;		/* Or in the type bit	*/
@@ -591,7 +591,7 @@ ReturnCode dosizeof(struct Global *global, int *result)
   if (c == ')') {                         /* Last syntax check    */
     for (testp = test_table; *testp != 0; testp++) {
       if (!bittest(typecode & *testp)) {
-	cerror(global, ERROR_SIZEOF_ILLEGAL_TYPE);
+	fpp_cerror(global, ERROR_SIZEOF_ILLEGAL_TYPE);
 	return(FPP_SIZEOF_ERROR);
       }
     }
@@ -609,7 +609,7 @@ ReturnCode dosizeof(struct Global *global, int *result)
 	typecode &= ~T_INT;
     }
     if ((typecode & ~T_PTR) == 0) {
-      cerror(global, ERROR_SIZEOF_NO_TYPE);
+      fpp_cerror(global, ERROR_SIZEOF_NO_TYPE);
       return(FPP_SIZEOF_ERROR);
     }
     /*
@@ -623,11 +623,11 @@ ReturnCode dosizeof(struct Global *global, int *result)
 	return(FPP_OK);
       }
     }					/* We shouldn't fail    */
-    cerror(global, ERROR_SIZEOF_BUG, typecode);
+    fpp_cerror(global, ERROR_SIZEOF_BUG, typecode);
     return(FPP_SIZEOF_ERROR);
   }
   fpp_unget(global);
-  cerror(global, ERROR_SIZEOF_SYNTAX);
+  fpp_cerror(global, ERROR_SIZEOF_SYNTAX);
   return(FPP_SIZEOF_ERROR);
 }
 
@@ -778,7 +778,7 @@ int evalchar(struct Global *global,
 #endif
   while ((c = fpp_get(global)) != '\'' && c != EOF_CHAR && c != '\n') {
     if (!skip)
-      cwarn(global, WARN_MULTIBYTE_NOT_PORTABLE, c);
+      fpp_cwarn(global, WARN_MULTIBYTE_NOT_PORTABLE, c);
 #if BIG_ENDIAN
     count += BITS_CHAR;
     value += (c << count);
@@ -827,7 +827,7 @@ int *evaleval(struct Global *global,
   case OP_MOD:
     if (v2 == 0) {
       if (!skip) {
-	cwarn(global, WARN_DIVISION_BY_ZERO,
+	fpp_cwarn(global, WARN_DIVISION_BY_ZERO,
 	      (op == OP_DIV) ? "divide" : "mod");
       }
       v1 = 0;
@@ -895,7 +895,7 @@ int *evaleval(struct Global *global,
     v1 = !v1;
     break;
   default:
-    cerror(global, ERROR_IF_OPERAND, op);
+    fpp_cerror(global, ERROR_IF_OPERAND, op);
     v1 = 0;
   }
   *valp++ = v1;

--- a/cpp5.c
+++ b/cpp5.c
@@ -26,7 +26,7 @@ SOFTWARE.
 
 INLINE FILE_LOCAL ReturnCode fpp_evallex(struct Global *, int, int *);
 INLINE FILE_LOCAL ReturnCode fpp_dosizeof(struct Global *, int *);
-INLINE FILE_LOCAL int bittest(int);
+INLINE FILE_LOCAL int fpp_bittest(int);
 INLINE FILE_LOCAL int fpp_evalnum(struct Global *, int);
 INLINE FILE_LOCAL int fpp_evalchar(struct Global *, int);
 INLINE FILE_LOCAL int *fpp_evaleval(struct Global *, int *, int, int);
@@ -590,7 +590,7 @@ ReturnCode fpp_dosizeof(struct Global *global, int *result)
   }
   if (c == ')') {                         /* Last syntax check    */
     for (testp = test_table; *testp != 0; testp++) {
-      if (!bittest(typecode & *testp)) {
+      if (!fpp_bittest(typecode & *testp)) {
 	fpp_cerror(global, ERROR_SIZEOF_ILLEGAL_TYPE);
 	return(FPP_SIZEOF_ERROR);
       }
@@ -632,7 +632,7 @@ ReturnCode fpp_dosizeof(struct Global *global, int *result)
 }
 
 INLINE FILE_LOCAL
-int bittest(int value)
+int fpp_bittest(int value)
 {
   /*
    * FPP_TRUE if value is zero or exactly one bit is set in value.

--- a/cpp5.c
+++ b/cpp5.c
@@ -24,12 +24,12 @@ SOFTWARE.
 #include "cppdef.h"
 #include "cpp.h"
 
-INLINE FILE_LOCAL ReturnCode evallex(struct Global *, int, int *);
+INLINE FILE_LOCAL ReturnCode fpp_evallex(struct Global *, int, int *);
 INLINE FILE_LOCAL ReturnCode dosizeof(struct Global *, int *);
 INLINE FILE_LOCAL int bittest(int);
-INLINE FILE_LOCAL int evalnum(struct Global *, int);
-INLINE FILE_LOCAL int evalchar(struct Global *, int);
-INLINE FILE_LOCAL int *evaleval(struct Global *, int *, int, int);
+INLINE FILE_LOCAL int fpp_evalnum(struct Global *, int);
+INLINE FILE_LOCAL int fpp_evalchar(struct Global *, int);
+INLINE FILE_LOCAL int *fpp_evaleval(struct Global *, int *, int, int);
 
 /*
  * Evaluate an #if expression.
@@ -216,15 +216,15 @@ SIZES size_table[] = {
 
 #endif /* OK_SIZEOF */
 
-ReturnCode eval(struct Global *global, int *eval)
+ReturnCode fpp_eval(struct Global *global, int *eval)
 {
   /*
    * Evaluate an expression.  Straight-forward operator precedence.
    * This is called from fpp_control() on encountering an #if statement.
    * It calls the following routines:
-   * evallex	Lexical analyser -- returns the type and value of
+   * fpp_evallex	Lexical analyser -- returns the type and value of
    *		the next input token.
-   * evaleval	Evaluate the current operator, given the values on
+   * fpp_evaleval	Evaluate the current operator, given the values on
    *		the value stack.  Returns a pointer to the (new)
    *		value stack.
    * For compatiblity with older cpp's, this return returns 1 (FPP_TRUE)
@@ -250,7 +250,7 @@ ReturnCode eval(struct Global *global, int *eval)
   binop = 0;
 
   while(again) {
-    ret=evallex(global, opp->skip, &op);
+    ret=fpp_evallex(global, opp->skip, &op);
     if(ret)
       return(ret);
     if (op == OP_SUB && binop == 0)
@@ -364,7 +364,7 @@ ReturnCode eval(struct Global *global, int *eval)
 	 */
       default:				/* Others:		*/
 	opp--;				/* Unstack the operator */
-	valp = evaleval(global, valp, op1, skip);
+	valp = fpp_evaleval(global, valp, op1, skip);
 	again=FPP_FALSE;
       }					/* op1 switch end	*/
     } while (!again);			/* Stack unwind loop	*/
@@ -373,16 +373,16 @@ ReturnCode eval(struct Global *global, int *eval)
 }
 
 INLINE FILE_LOCAL
-ReturnCode evallex(struct Global *global,
+ReturnCode fpp_evallex(struct Global *global,
 		   int skip,	/* FPP_TRUE if short-circuit evaluation */
 		   int *op)
 {
   /*
-   * Set *op to next eval operator or value. Called from eval(). It
+   * Set *op to next fpp_eval operator or value. Called from fpp_eval(). It
    * calls a special-purpose routines for 'char' strings and
    * numeric values:
-   * evalchar	called to evaluate 'x'
-   * evalnum	called to evaluate numbers.
+   * fpp_evalchar	called to evaluate 'x'
+   * fpp_evalnum	called to evaluate numbers.
    */
 
   int c, c1, t;
@@ -415,7 +415,7 @@ ReturnCode evallex(struct Global *global,
       return(FPP_ILLEGAL_CHARACTER);
     } else if (t == QUO) {                  /* ' or "               */
       if (c == '\'') {                    /* Character constant   */
-	global->evalue = evalchar(global, skip);  /* Somewhat messy       */
+	global->evalue = fpp_evalchar(global, skip);  /* Somewhat messy       */
 	*op=DIG;                          /* Return a value       */
 	return(FPP_OK);
       }
@@ -448,7 +448,7 @@ else if (streq(global->tokenbuf, "sizeof")) { /* New sizeof hackery   */
       return(FPP_OK);
     }
     else if (t == DIG) {                  /* Numbers are harder   */
-      global->evalue = evalnum(global, c);
+      global->evalue = fpp_evalnum(global, c);
     }
     else if (strchr("!=<>&|\\", c) != NULL) {
       /*
@@ -651,10 +651,10 @@ int bittest(int value)
 #endif /* OK_SIZEOF */
 
 INLINE FILE_LOCAL
-int evalnum(struct Global *global, int c)
+int fpp_evalnum(struct Global *global, int c)
 {
   /*
-   * Expand number for #if lexical analysis.  Note: evalnum recognizes
+   * Expand number for #if lexical analysis.  Note: fpp_evalnum recognizes
    * the unsigned suffix, but only returns a signed int value.
    */
 
@@ -690,7 +690,7 @@ int evalnum(struct Global *global, int c)
 }
 
 INLINE FILE_LOCAL
-int evalchar(struct Global *global,
+int fpp_evalchar(struct Global *global,
 	     int skip)		/* FPP_TRUE if short-circuit evaluation	*/
      /*
       * Get a character constant
@@ -792,7 +792,7 @@ int evalchar(struct Global *global,
 }
 
 INLINE FILE_LOCAL
-int *evaleval(struct Global *global,
+int *fpp_evaleval(struct Global *global,
 	      int *valp,
 	      int op,
 	      int skip)		/* FPP_TRUE if short-circuit evaluation	*/
@@ -804,7 +804,7 @@ int *evaleval(struct Global *global,
    *
    * OP_COL is a special case.
    *
-   * evaleval() returns the new pointer to the top of the value stack.
+   * fpp_evaleval() returns the new pointer to the top of the value stack.
    */
   int v1, v2 = 0;
   

--- a/cpp5.c
+++ b/cpp5.c
@@ -401,7 +401,7 @@ ReturnCode evallex(struct Global *global,
 	*op=OP_EOE;           /* End of expression    */
 	return(FPP_OK);
       }
-    } while ((t = type[c]) == LET && catenate(global, 0, &ret) && !ret);
+    } while ((t = type[c]) == LET && fpp_catenate(global, 0, &ret) && !ret);
     if(ret)
       /* If the loop was broken because of a fatal error! */
       return(ret);
@@ -562,7 +562,7 @@ ReturnCode dosizeof(struct Global *global, int *result)
     }
     else if (type[c] != LET)            /* Exit if not a type   */
       break;
-    else if (!catenate(global, 0, &ret) && !ret) { /* Maybe combine tokens */
+    else if (!fpp_catenate(global, 0, &ret) && !ret) { /* Maybe combine tokens */
       /*
        * Look for this unexpandable token in basic_types.
        * The code accepts "int long" as well as "long int"

--- a/cpp5.c
+++ b/cpp5.c
@@ -427,7 +427,7 @@ ReturnCode fpp_evallex(struct Global *global,
 	if (c == '(')                     /* Allow defined(name)  */
 	  c = fpp_skipws(global);
 	if (type[c] == LET) {
-	  global->evalue = (lookid(global, c) != NULL);
+	  global->evalue = (fpp_lookid(global, c) != NULL);
 	  if (c1 != '('                   /* Need to balance      */
 	      || fpp_skipws(global) == ')') { /* Did we balance?      */
 	    *op=DIG;

--- a/cpp5.c
+++ b/cpp5.c
@@ -454,7 +454,7 @@ else if (streq(global->tokenbuf, "sizeof")) { /* New sizeof hackery   */
       /*
        * Process a possible multi-byte lexeme.
        */
-      c1 = cget(global);                        /* Peek at next char    */
+      c1 = fpp_cget(global);                        /* Peek at next char    */
       switch (c) {
       case '!':
 	if (c1 == '=') {
@@ -664,9 +664,9 @@ int evalnum(struct Global *global, int c)
   
   if (c != '0')
     base = 10;
-  else if ((c = cget(global)) == 'x' || c == 'X') {
+  else if ((c = fpp_cget(global)) == 'x' || c == 'X') {
     base = 16;
-    c = cget(global);
+    c = fpp_cget(global);
   }
   else base = 8;
   value = 0;
@@ -681,10 +681,10 @@ int evalnum(struct Global *global, int c)
       break;
     value *= base;
     value += c1;
-    c = cget(global);
+    c = fpp_cget(global);
   }
   if (c == 'u' || c == 'U')       /* Unsigned nonsense            */
-    c = cget(global);
+    c = fpp_cget(global);
   unget(global);
   return (value);
 }
@@ -701,8 +701,8 @@ int evalchar(struct Global *global,
   int count;
   
   global->instring = FPP_TRUE;
-  if ((c = cget(global)) == '\\') {
-    switch ((c = cget(global))) {
+  if ((c = fpp_cget(global)) == '\\') {
+    switch ((c = fpp_cget(global))) {
     case 'a':                           /* New in Standard      */
 #if ('a' == '\a' || '\a' == ALERT)
       value = ALERT;			/* Use predefined value */

--- a/cpp5.c
+++ b/cpp5.c
@@ -673,7 +673,7 @@ int fpp_evalnum(struct Global *global, int c)
   for (;;) {
     c1 = c;
     if (isascii(c) && isupper(c1))
-      c1 = tolower(c1);
+      c1 = fpp_tolower(c1);
     if (c1 >= 'a')
       c1 -= ('a' - 10);
     else c1 -= '0';

--- a/cpp5.c
+++ b/cpp5.c
@@ -397,7 +397,7 @@ ReturnCode evallex(struct Global *global,
       if((ret=macroid(global, &c)))
       return(ret);
       if (c == EOF_CHAR || c == '\n') {
-	unget(global);
+	fpp_unget(global);
 	*op=OP_EOE;           /* End of expression    */
 	return(FPP_OK);
       }
@@ -465,7 +465,7 @@ else if (streq(global->tokenbuf, "sizeof")) { /* New sizeof hackery   */
 	
       case '=':
 	if (c1 != '=') {                  /* Can't say a=b in #if */
-	  unget(global);
+	  fpp_unget(global);
 	  cerror(global, ERROR_ILLEGAL_ASSIGN);
 	  return (FPP_IF_ERROR);
 	}
@@ -500,7 +500,7 @@ else if (streq(global->tokenbuf, "sizeof")) { /* New sizeof hackery   */
 	return(FPP_IF_ERROR);
       }
       if(!loop)
-	unget(global);
+	fpp_unget(global);
     }
   } while(loop);
   *op=t;
@@ -526,7 +526,7 @@ ReturnCode dosizeof(struct Global *global, int *result)
   ReturnCode ret;
   
   if ((c = skipws(global)) != '(') {
-    unget(global);
+    fpp_unget(global);
     cerror(global, ERROR_SIZEOF_SYNTAX);
     return(FPP_SIZEOF_ERROR);
   }
@@ -540,22 +540,22 @@ ReturnCode dosizeof(struct Global *global, int *result)
     /* (I) return on fail! */
     if (c  == EOF_CHAR || c == '\n') {
       /* End of line is a bug */
-      unget(global);
+      fpp_unget(global);
       cerror(global, ERROR_SIZEOF_SYNTAX);
       return(FPP_SIZEOF_ERROR);
     } else if (c == '(') {                /* thing (*)() func ptr */
       if (skipws(global) == '*'
 	  && skipws(global) == ')') {         /* We found (*)         */
 	if (skipws(global) != '(')            /* Let () be optional   */
-	  unget(global);
+	  fpp_unget(global);
 	else if (skipws(global) != ')') {
-	  unget(global);
+	  fpp_unget(global);
 	  cerror(global, ERROR_SIZEOF_SYNTAX);
 	  return(FPP_SIZEOF_ERROR);
 	}
 	typecode |= T_FPTR; 		/* Function pointer	*/
       } else {				/* Junk is a bug	*/
-	unget(global);
+	fpp_unget(global);
 	cerror(global, ERROR_SIZEOF_SYNTAX);
 	return(FPP_SIZEOF_ERROR);
       }
@@ -626,7 +626,7 @@ ReturnCode dosizeof(struct Global *global, int *result)
     cerror(global, ERROR_SIZEOF_BUG, typecode);
     return(FPP_SIZEOF_ERROR);
   }
-  unget(global);
+  fpp_unget(global);
   cerror(global, ERROR_SIZEOF_SYNTAX);
   return(FPP_SIZEOF_ERROR);
 }
@@ -685,7 +685,7 @@ int evalnum(struct Global *global, int c)
   }
   if (c == 'u' || c == 'U')       /* Unsigned nonsense            */
     c = fpp_cget(global);
-  unget(global);
+  fpp_unget(global);
   return (value);
 }
 
@@ -749,7 +749,7 @@ int evalchar(struct Global *global,
 	value *= 16;
 	value += (c <= '9') ? (c - '0') : ((c & 0xF) + 9);
       }
-      unget(global);
+      fpp_unget(global);
       break;
       
     default:
@@ -761,7 +761,7 @@ int evalchar(struct Global *global,
 	  value += (c - '0');
 	  c = fpp_get(global);
 	}
-	unget(global);
+	fpp_unget(global);
       } else
 	value = c;
       break;

--- a/cpp5.c
+++ b/cpp5.c
@@ -92,7 +92,7 @@ static char opdope[OP_MAX] = {
 typedef struct optab {
   char	op;			/* Operator			*/
   char	prec;			/* Its precedence		*/
-  char	skip;			/* Short-circuit: TRUE to skip	*/
+  char	skip;			/* Short-circuit: FPP_TRUE to skip	*/
 } OPTAB;
      
 #ifdef	nomacargs
@@ -227,7 +227,7 @@ ReturnCode eval(struct Global *global, int *eval)
    * evaleval	Evaluate the current operator, given the values on
    *		the value stack.  Returns a pointer to the (new)
    *		value stack.
-   * For compatiblity with older cpp's, this return returns 1 (TRUE)
+   * For compatiblity with older cpp's, this return returns 1 (FPP_TRUE)
    * if a syntax error is detected.
    */
   int op;		/* Current operator		*/
@@ -240,7 +240,7 @@ ReturnCode eval(struct Global *global, int *eval)
   int value[NEXP];	/* Value stack			*/
   OPTAB opstack[NEXP];	/* Operand stack		*/
   ReturnCode ret;
-  char again=TRUE;
+  char again=FPP_TRUE;
   
   valp = value;
   opp = opstack;
@@ -274,7 +274,7 @@ ReturnCode eval(struct Global *global, int *eval)
 	*valp++ = global->evalue;
 	binop = 1;
       }
-      again=TRUE;
+      again=FPP_TRUE;
       continue;
     } else if (op > OP_END) {
       cerror(global, ERROR_ILLEGAL_IF_LINE);
@@ -323,7 +323,7 @@ ReturnCode eval(struct Global *global, int *eval)
 	else {				/* Other ops leave	*/
 	  opp->skip = op1;		/*  skipping unchanged. */
 	}
-	again=TRUE;
+	again=FPP_TRUE;
 	continue;
       }
       /*
@@ -338,7 +338,7 @@ ReturnCode eval(struct Global *global, int *eval)
 	  return(FPP_OK);
 	}
 	/* Read another op.	*/
-	again=TRUE;
+	again=FPP_TRUE;
 	continue;
       case OP_LPA:			/* ( on stack           */
 	if (op != OP_RPA) {             /* Matches ) on input   */
@@ -350,7 +350,7 @@ ReturnCode eval(struct Global *global, int *eval)
 	/* -- Fall through 	*/
       case OP_QUE:
 	/* Evaluate true expr.	*/
-	again=TRUE;
+	again=FPP_TRUE;
 	continue;
       case OP_COL:			/* : on stack.		*/
 	opp--;				/* Unstack :		*/
@@ -365,7 +365,7 @@ ReturnCode eval(struct Global *global, int *eval)
       default:				/* Others:		*/
 	opp--;				/* Unstack the operator */
 	valp = evaleval(global, valp, op1, skip);
-	again=FALSE;
+	again=FPP_FALSE;
       }					/* op1 switch end	*/
     } while (!again);			/* Stack unwind loop	*/
   }
@@ -374,7 +374,7 @@ ReturnCode eval(struct Global *global, int *eval)
 
 INLINE FILE_LOCAL
 ReturnCode evallex(struct Global *global,
-		   int skip,	/* TRUE if short-circuit evaluation */
+		   int skip,	/* FPP_TRUE if short-circuit evaluation */
 		   int *op)
 {
   /*
@@ -391,7 +391,7 @@ ReturnCode evallex(struct Global *global,
   
   do { /* while(loop); */
   /* again: */
-    loop=FALSE;
+    loop=FPP_FALSE;
     do {					/* Collect the token	*/
       c = skipws(global);
       if((ret=macroid(global, &c)))
@@ -493,7 +493,7 @@ else if (streq(global->tokenbuf, "sizeof")) { /* New sizeof hackery   */
       
       case '\\':
 	if (c1 == '\n') {                  /* Multi-line if        */
-	  loop=TRUE;
+	  loop=FPP_TRUE;
 	  break;
 	}
 	cerror(global, ERROR_ILLEGAL_BACKSLASH);
@@ -635,7 +635,7 @@ INLINE FILE_LOCAL
 int bittest(int value)
 {
   /*
-   * TRUE if value is zero or exactly one bit is set in value.
+   * FPP_TRUE if value is zero or exactly one bit is set in value.
    */
 
 #if (4096 & ~(-4096)) == 0
@@ -691,7 +691,7 @@ int evalnum(struct Global *global, int c)
 
 INLINE FILE_LOCAL
 int evalchar(struct Global *global,
-	     int skip)		/* TRUE if short-circuit evaluation	*/
+	     int skip)		/* FPP_TRUE if short-circuit evaluation	*/
      /*
       * Get a character constant
       */
@@ -700,7 +700,7 @@ int evalchar(struct Global *global,
   int value;
   int count;
   
-  global->instring = TRUE;
+  global->instring = FPP_TRUE;
   if ((c = cget(global)) == '\\') {
     switch ((c = cget(global))) {
     case 'a':                           /* New in Standard      */
@@ -787,7 +787,7 @@ int evalchar(struct Global *global,
     value += c;
 #endif
   }
-  global->instring = FALSE;
+  global->instring = FPP_FALSE;
   return (value);
 }
 
@@ -795,7 +795,7 @@ INLINE FILE_LOCAL
 int *evaleval(struct Global *global,
 	      int *valp,
 	      int op,
-	      int skip)		/* TRUE if short-circuit evaluation	*/
+	      int skip)		/* FPP_TRUE if short-circuit evaluation	*/
 {
   /*
    * Apply the argument operator to the data on the value stack.

--- a/cpp6.c
+++ b/cpp6.c
@@ -40,7 +40,7 @@ INLINE FILE_LOCAL void domsg(struct Global *, ErrorCode, va_list);
  *              If it is a #defined macro, it is expanded, and
  *              macroid() returns FPP_TRUE, otherwise, FPP_FALSE.
  * fpp_catenate()   Does the dirty work of token concatenation, FPP_TRUE if it did.
- * scanstring() Reads a string from the input stream, calling
+ * fpp_scanstring() Reads a string from the input stream, calling
  *              a user-supplied function for each character.
  *              This function may be output() to write the
  *              string to the output file, or fpp_save() to fpp_save
@@ -56,7 +56,7 @@ INLINE FILE_LOCAL void domsg(struct Global *, ErrorCode, va_list);
  * Getmem()     Get a specified number of bytes from malloc memory.
  * output()     Write one character to stdout (calling fpp_Putchar) --
  *              implemented as a function so its address may be
- *              passed to scanstring() and fpp_scannumber().
+ *              passed to fpp_scanstring() and fpp_scannumber().
  * lookid()     Scans the next token (identifier) from the input
  *              stream.  Looks for it in the #defined symbol table.
  *              Returns a pointer to the definition, if found, or NULL
@@ -280,7 +280,7 @@ int fpp_catenate(struct Global *global, int lhs_number, ReturnCode *ret)
 #endif
 }
 
-ReturnCode scanstring(struct Global *global,
+ReturnCode fpp_scanstring(struct Global *global,
                       int delim, /* ' or " */
                       /* Output function: */
                       ReturnCode (*outfun)(struct Global *, int))

--- a/cpp6.c
+++ b/cpp6.c
@@ -54,7 +54,7 @@ INLINE FILE_LOCAL void domsg(struct Global *, ErrorCode, va_list);
  *              #include opens a new file, or a macro is to be
  *              expanded.
  * Getmem()     Get a specified number of bytes from malloc memory.
- * output()     Write one character to stdout (calling Putchar) --
+ * output()     Write one character to stdout (calling fpp_Putchar) --
  *              implemented as a function so its address may be
  *              passed to scanstring() and scannumber().
  * lookid()     Scans the next token (identifier) from the input
@@ -650,33 +650,33 @@ void outadefine(struct Global *global, DEFBUF *dp)
 
   if (dp->nargs > 0) {
     int i;
-    Putchar(global, '(');
+    fpp_Putchar(global, '(');
     for (i = 1; i < dp->nargs; i++) {
       /* printf("__%d,", i); */
       Putstring(global, "__");
       Putint(global, i);
-      Putchar(global, ',');
+      fpp_Putchar(global, ',');
     }
     /* printf("__%d)", i); */
     Putstring(global, "__");
     Putint(global, i);
-    Putchar(global, ')');
+    fpp_Putchar(global, ')');
 
   } else if (dp->nargs == 0) {
     Putstring(global, "()");
   }
   if (dp->repl != NULL) {
-    Putchar(global, '\t');
+    fpp_Putchar(global, '\t');
     for (cp = dp->repl; (c = *cp++ & 0xFF) != EOS;) {
       if (c >= MAC_PARM && c < (MAC_PARM + PAR_MAC)) {
         /* printf("__%d", c - MAC_PARM + 1); */
         Putstring(global, "__");
         Putint(global, c - MAC_PARM + 1);
       } else if (isprint(c) || c == '\t' || c == '\n')
-        Putchar(global, c);
+        fpp_Putchar(global, c);
       else switch (c) {
       case QUOTE_PARM:
-        Putchar(global, '#');
+        fpp_Putchar(global, '#');
         break;
       case DEF_MAGIC:       /* Special anti-recursion */
       case MAC_PARM + PAR_MAC:    /* Special "arg" marker */
@@ -685,7 +685,7 @@ void outadefine(struct Global *global, DEFBUF *dp)
 #if COMMENT_INVISIBLE
         Putstring(global, "/**/");
 #else
-        Putchar(global, ' ');
+        fpp_Putchar(global, ' ');
 #endif
         break;
       case TOK_SEP:
@@ -701,7 +701,7 @@ void outadefine(struct Global *global, DEFBUF *dp)
       }
     }
   }
-  Putchar(global, '\n');
+  fpp_Putchar(global, '\n');
 }
 
 /*
@@ -828,12 +828,12 @@ int fpp_get(struct Global *global)
       }
 
       if(c=='*') {
-        Putchar(global, '/');           /* Write out the         */
-        Putchar(global, '*');           /*   initializer         */
+        fpp_Putchar(global, '/');           /* Write out the         */
+        fpp_Putchar(global, '*');           /*   initializer         */
       } else {
         /* C++ style comment */
-        Putchar(global, '/');           /* Write out the         */
-        Putchar(global, '/');           /*   initializer         */
+        fpp_Putchar(global, '/');           /* Write out the         */
+        fpp_Putchar(global, '/');           /*   initializer         */
       }
     }
 
@@ -841,7 +841,7 @@ int fpp_get(struct Global *global)
       do {
         c=fpp_get(global);
         if(global->keepcomments)
-          Putchar(global, c);
+          fpp_Putchar(global, c);
       } while(c!='\n' && c!=EOF_CHAR);  /* eat all to EOL or EOF */
       global->instring = FPP_FALSE;         /* End of comment        */
       return(c);                        /* Return the end char   */
@@ -851,7 +851,7 @@ int fpp_get(struct Global *global)
       c = fpp_get(global);
     test:
       if (global->keepcomments && c != EOF_CHAR)
-        Putchar(global, c);
+        fpp_Putchar(global, c);
       switch (c) {
       case EOF_CHAR:
         cerror(global, ERROR_EOF_IN_COMMENT);
@@ -873,7 +873,7 @@ int fpp_get(struct Global *global)
         if ((c = fpp_get(global)) != '/')           /* If comment doesn't   */
           goto test;                    /* end, look at next    */
         if (global->keepcomments) {     /* Put out the comment  */
-          Putchar(global, c);           /* terminator, too      */
+          fpp_Putchar(global, c);           /* terminator, too      */
         }
         if(--comments)
           /* nested comment, continue! */

--- a/cpp6.c
+++ b/cpp6.c
@@ -61,7 +61,7 @@ INLINE FILE_LOCAL void domsg(struct Global *, ErrorCode, va_list);
  *              stream.  Looks for it in the #defined symbol table.
  *              Returns a pointer to the definition, if found, or NULL
  *              if not present.  The identifier is stored in tokenbuf.
- * defnedel()   Define enter/delete subroutine.  Updates the
+ * fpp_defendel()   Define enter/delete subroutine.  Updates the
  *              symbol table.
  * fpp_get()        Read the next byte from the current input stream,
  *              handling end of (macro/file) input and embedded
@@ -572,7 +572,7 @@ DEFBUF *fpp_lookid(struct Global *global,
   return((temp == 0) ? dp : NULL);
 }
 
-DEFBUF *defendel(struct Global *global,
+DEFBUF *fpp_defendel(struct Global *global,
                  char *name,
                  int delete)            /* FPP_TRUE to delete a symbol */
 {

--- a/cpp6.c
+++ b/cpp6.c
@@ -57,7 +57,7 @@ INLINE FILE_LOCAL void domsg(struct Global *, ErrorCode, va_list);
  * output()     Write one character to stdout (calling fpp_Putchar) --
  *              implemented as a function so its address may be
  *              passed to fpp_scanstring() and fpp_scannumber().
- * lookid()     Scans the next token (identifier) from the input
+ * fpp_lookid()     Scans the next token (identifier) from the input
  *              stream.  Looks for it in the #defined symbol table.
  *              Returns a pointer to the definition, if found, or NULL
  *              if not present.  The identifier is stored in tokenbuf.
@@ -156,7 +156,7 @@ void fpp_scanid(struct Global *global,
 {
   /*
    * Get the next token (an id) into the token buffer.
-   * Note: this code is duplicated in lookid().
+   * Note: this code is duplicated in fpp_lookid().
    * Change one, change both.
    */
 
@@ -191,7 +191,7 @@ ReturnCode fpp_macroid(struct Global *global, int *c)
 
   if (global->infile != NULL && global->infile->fp != NULL)
     global->recursion = 0;
-  while (type[*c] == LET && (dp = lookid(global, *c)) != NULL) {
+  while (type[*c] == LET && (dp = fpp_lookid(global, *c)) != NULL) {
     if((ret=fpp_expand(global, dp)))
       return(ret);
     *c = fpp_get(global);
@@ -230,7 +230,7 @@ int fpp_catenate(struct Global *global, int lhs_number, ReturnCode *ret)
         return(FPP_FALSE);
     } /* BK - BUG? Parses token into global->tokenbuf but never uses it.
       else
-      lookid(global, c);
+      fpp_lookid(global, c);
       */
     switch(type[c]) {                   /* What was it?         */
     case LET:                           /* An identifier, ...   */
@@ -532,7 +532,7 @@ ReturnCode fpp_getfile(struct Global *global,
  *                      C P P   S y m b o l   T a b l e s
  */
 
-DEFBUF *lookid(struct Global *global,
+DEFBUF *fpp_lookid(struct Global *global,
                int c)           /* First character of token     */
 {
   /*

--- a/cpp6.c
+++ b/cpp6.c
@@ -29,7 +29,7 @@ INLINE FILE_LOCAL void domsg(struct Global *, ErrorCode, va_list);
 
 /*
  * fpp_skipnl()     skips over input text to the end of the line.
- * skipws()     skips over "whitespace" (spaces or tabs), but
+ * fpp_skipws()     skips over "whitespace" (spaces or tabs), but
  *              not skip over the end of the line.  It skips over
  *              TOK_SEP, however (though that shouldn't happen).
  * fpp_scanid()     reads the next token (C identifier) into tokenbuf.
@@ -134,7 +134,7 @@ void fpp_skipnl(struct Global *global)
   return;
 }
 
-int skipws(struct Global *global)
+int fpp_skipws(struct Global *global)
 {
   /*
    * Skip over whitespace

--- a/cpp6.c
+++ b/cpp6.c
@@ -654,12 +654,12 @@ void outadefine(struct Global *global, DEFBUF *dp)
     for (i = 1; i < dp->nargs; i++) {
       /* printf("__%d,", i); */
       fpp_Putstring(global, "__");
-      Putint(global, i);
+      fpp_Putint(global, i);
       fpp_Putchar(global, ',');
     }
     /* printf("__%d)", i); */
     fpp_Putstring(global, "__");
-    Putint(global, i);
+    fpp_Putint(global, i);
     fpp_Putchar(global, ')');
 
   } else if (dp->nargs == 0) {
@@ -671,7 +671,7 @@ void outadefine(struct Global *global, DEFBUF *dp)
       if (c >= MAC_PARM && c < (MAC_PARM + PAR_MAC)) {
         /* printf("__%d", c - MAC_PARM + 1); */
         fpp_Putstring(global, "__");
-        Putint(global, c - MAC_PARM + 1);
+        fpp_Putint(global, c - MAC_PARM + 1);
       } else if (isprint(c) || c == '\t' || c == '\n')
         fpp_Putchar(global, c);
       else switch (c) {

--- a/cpp6.c
+++ b/cpp6.c
@@ -53,7 +53,7 @@ INLINE FILE_LOCAL void domsg(struct Global *, ErrorCode, va_list);
  * fpp_getfile()    Initialize a new FILEINFO structure, called when
  *              #include opens a new file, or a macro is to be
  *              expanded.
- * Getmem()     Get a specified number of bytes from malloc memory.
+ * fpp_Getmem()     Get a specified number of bytes from malloc memory.
  * output()     Write one character to stdout (calling fpp_Putchar) --
  *              implemented as a function so its address may be
  *              passed to fpp_scanstring() and fpp_scannumber().

--- a/cpp6.c
+++ b/cpp6.c
@@ -39,7 +39,7 @@ INLINE FILE_LOCAL void domsg(struct Global *, ErrorCode, va_list);
  * macroid()    reads the next token (C identifier) into tokenbuf.
  *              If it is a #defined macro, it is expanded, and
  *              macroid() returns FPP_TRUE, otherwise, FPP_FALSE.
- * catenate()   Does the dirty work of token concatenation, FPP_TRUE if it did.
+ * fpp_catenate()   Does the dirty work of token concatenation, FPP_TRUE if it did.
  * scanstring() Reads a string from the input stream, calling
  *              a user-supplied function for each character.
  *              This function may be output() to write the
@@ -199,7 +199,7 @@ ReturnCode macroid(struct Global *global, int *c)
   return(FPP_OK);
 }
 
-int catenate(struct Global *global, int lhs_number, ReturnCode *ret)
+int fpp_catenate(struct Global *global, int lhs_number, ReturnCode *ret)
 {
   /*
    * A token was just read (via macroid).

--- a/cpp6.c
+++ b/cpp6.c
@@ -28,7 +28,7 @@ INLINE FILE_LOCAL void outadefine(struct Global *, DEFBUF *);
 INLINE FILE_LOCAL void domsg(struct Global *, ErrorCode, va_list);
 
 /*
- * skipnl()     skips over input text to the end of the line.
+ * fpp_skipnl()     skips over input text to the end of the line.
  * skipws()     skips over "whitespace" (spaces or tabs), but
  *              not skip over the end of the line.  It skips over
  *              TOK_SEP, however (though that shouldn't happen).
@@ -121,7 +121,7 @@ char type[256] = {              /* Character type codes    Hex          */
   000,   000,    000,   000,   000,   000,   000,   000, /*   80 .. FF  */
 };
 
-void skipnl(struct Global *global)
+void fpp_skipnl(struct Global *global)
 {
   /*
    * Skip to the end of the current input line.

--- a/cpp6.c
+++ b/cpp6.c
@@ -24,7 +24,7 @@ SOFTWARE.
 #include "cppdef.h"
 #include "cpp.h"
 
-INLINE FILE_LOCAL void outadefine(struct Global *, DEFBUF *);
+INLINE FILE_LOCAL void fpp_outadefine(struct Global *, DEFBUF *);
 INLINE FILE_LOCAL void fpp_domsg(struct Global *, ErrorCode, va_list);
 
 /*
@@ -632,14 +632,14 @@ void fpp_outdefines(struct Global *global)
   for (syp = global->symtab; syp < &global->symtab[SBSIZE]; syp++) {
     if ((dp = *syp) != (DEFBUF *) NULL) {
       do {
-        outadefine(global, dp);
+        fpp_outadefine(global, dp);
       } while ((dp = dp->link) != (DEFBUF *) NULL);
     }
   }
 }
 
 INLINE FILE_LOCAL
-void outadefine(struct Global *global, DEFBUF *dp)
+void fpp_outadefine(struct Global *global, DEFBUF *dp)
 {
   char *cp;
   int c;

--- a/cpp6.c
+++ b/cpp6.c
@@ -623,7 +623,7 @@ DEFBUF *defendel(struct Global *global,
 }
 
 
-void outdefines(struct Global *global)
+void fpp_outdefines(struct Global *global)
 {
   DEFBUF *dp;
   DEFBUF **syp;

--- a/cpp6.c
+++ b/cpp6.c
@@ -45,7 +45,7 @@ INLINE FILE_LOCAL void domsg(struct Global *, ErrorCode, va_list);
  *              This function may be output() to write the
  *              string to the output file, or fpp_save() to fpp_save
  *              the string in the work buffer.
- * scannumber() Reads a C numeric constant from the input stream,
+ * fpp_scannumber() Reads a C numeric constant from the input stream,
  *              calling the user-supplied function for each
  *              character.  (output() or fpp_save() as noted above.)
  * fpp_save()       Save one character in the work[] buffer.
@@ -56,7 +56,7 @@ INLINE FILE_LOCAL void domsg(struct Global *, ErrorCode, va_list);
  * Getmem()     Get a specified number of bytes from malloc memory.
  * output()     Write one character to stdout (calling fpp_Putchar) --
  *              implemented as a function so its address may be
- *              passed to scanstring() and scannumber().
+ *              passed to scanstring() and fpp_scannumber().
  * lookid()     Scans the next token (identifier) from the input
  *              stream.  Looks for it in the #defined symbol table.
  *              Returns a pointer to the definition, if found, or NULL
@@ -245,7 +245,7 @@ int fpp_catenate(struct Global *global, int lhs_number, ReturnCode *ret)
     case DOT:                           /* Or maybe a float     */
       strcpy(global->work, token1);
       global->workp = global->work + strlen(global->work);
-      *ret=scannumber(global, c, fpp_save);
+      *ret=fpp_scannumber(global, c, fpp_save);
       if(*ret)
         return(FPP_FALSE);
       *ret=fpp_save(global, EOS);
@@ -321,7 +321,7 @@ ReturnCode scanstring(struct Global *global,
   }
 }
 
-ReturnCode scannumber(struct Global *global,
+ReturnCode fpp_scannumber(struct Global *global,
                       int c,            /* First char of number */
                       /* Output/store func: */
                       ReturnCode (*outfun)(struct Global *, int))

--- a/cpp6.c
+++ b/cpp6.c
@@ -25,7 +25,7 @@ SOFTWARE.
 #include "cpp.h"
 
 INLINE FILE_LOCAL void outadefine(struct Global *, DEFBUF *);
-INLINE FILE_LOCAL void domsg(struct Global *, ErrorCode, va_list);
+INLINE FILE_LOCAL void fpp_domsg(struct Global *, ErrorCode, va_list);
 
 /*
  * fpp_skipnl()     skips over input text to the end of the line.
@@ -988,7 +988,7 @@ int fpp_cget(struct Global *global)
  */
 
 INLINE FILE_LOCAL
-void domsg(struct Global *global,
+void fpp_domsg(struct Global *global,
   ErrorCode error,  /* error message number */
   va_list arg)      /* Something for the message    */
 {
@@ -1125,7 +1125,7 @@ void fpp_cerror(struct Global *global,
    */
   va_list arg;
   va_start(arg, message);
-  domsg(global, message, arg);
+  fpp_domsg(global, message, arg);
 }
 
 void fpp_Error(struct Global *global, char *format, ...)

--- a/cpp6.c
+++ b/cpp6.c
@@ -69,7 +69,7 @@ INLINE FILE_LOCAL void domsg(struct Global *, ErrorCode, va_list);
  *              instring is -- essentially -- a parameter to fpp_get().
  * fpp_cget()       Like fpp_get(), but skip over TOK_SEP.
  * fpp_unget()      Push last gotten character back on the input stream.
- * cerror()     This routine format an print messages to the user.
+ * fpp_cerror()     This routine format an print messages to the user.
  */
 
 /*
@@ -235,7 +235,7 @@ int fpp_catenate(struct Global *global, int lhs_number, ReturnCode *ret)
     switch(type[c]) {                   /* What was it?         */
     case LET:                           /* An identifier, ...   */
       if ((int)strlen(token1) + (int)strlen(global->tokenbuf) >= NWORK) {
-        cfatal(global, FATAL_WORK_AREA_OVERFLOW, token1);
+        fpp_cfatal(global, FATAL_WORK_AREA_OVERFLOW, token1);
         *ret=FPP_WORK_AREA_OVERFLOW;
         return(FPP_FALSE);
       }
@@ -254,9 +254,9 @@ int fpp_catenate(struct Global *global, int lhs_number, ReturnCode *ret)
       break;
     default:                            /* An error, ...        */
       if (isprint(c))
-        cerror(global, ERROR_STRANG_CHARACTER, c);
+        fpp_cerror(global, ERROR_STRANG_CHARACTER, c);
       else
-        cerror(global, ERROR_STRANG_CHARACTER2, c);
+        fpp_cerror(global, ERROR_STRANG_CHARACTER2, c);
       strcpy(global->work, token1);
       fpp_unget(global);
       break;
@@ -315,7 +315,7 @@ ReturnCode scanstring(struct Global *global,
     ret=(*outfun)(global, c);
     return(ret);
   } else {
-    cerror(global, ERROR_UNTERMINATED_STRING);
+    fpp_cerror(global, ERROR_UNTERMINATED_STRING);
     fpp_unget(global);
     return(FPP_UNTERMINATED_STRING);
   }
@@ -465,7 +465,7 @@ ReturnCode scannumber(struct Global *global,
   fpp_unget(global);                         /* Not part of a number */
   if(!(global->webmode)) {
     if (octal89 && radix == 8)
-      cwarn(global, WARN_ILLEGAL_OCTAL);
+      fpp_cwarn(global, WARN_ILLEGAL_OCTAL);
   }
   return(FPP_OK);
 }
@@ -473,7 +473,7 @@ ReturnCode scannumber(struct Global *global,
 ReturnCode save(struct Global *global, int c)
 {
   if (global->workp >= &global->work[NWORK]) {
-    cfatal(global, FATAL_WORK_BUFFER_OVERFLOW);
+    fpp_cfatal(global, FATAL_WORK_BUFFER_OVERFLOW);
     return(FPP_WORK_AREA_OVERFLOW);
   } else
     *global->workp++ = c;
@@ -854,7 +854,7 @@ int fpp_get(struct Global *global)
         fpp_Putchar(global, c);
       switch (c) {
       case EOF_CHAR:
-        cerror(global, ERROR_EOF_IN_COMMENT);
+        fpp_cerror(global, ERROR_EOF_IN_COMMENT);
         return (EOF_CHAR);
 
       case '/':
@@ -862,7 +862,7 @@ int fpp_get(struct Global *global)
           if((c = fpp_get(global)) != '*')
             goto test;
           if(global->warnnestcomments) {
-            cwarn(global, WARN_NESTED_COMMENT);
+            fpp_cwarn(global, WARN_NESTED_COMMENT);
           }
           if(global->nestcomments)
             comments++;
@@ -941,7 +941,7 @@ void fpp_unget(struct Global *global)
   if ((file = global->infile) == NULL)
     return;                     /* Unget after EOF            */
   if (--file->bptr < file->buffer) {
-    cfatal(global, FATAL_TOO_MUCH_PUSHBACK);
+    fpp_cfatal(global, FATAL_TOO_MUCH_PUSHBACK);
     /* This happens only if used the wrong way! */
     return;
   }
@@ -1116,7 +1116,7 @@ void domsg(struct Global *global,
     global->errors++;
 }
 
-void cerror(struct Global *global,
+void fpp_cerror(struct Global *global,
             ErrorCode message,
             ...)        /* arguments    */
 {

--- a/cpp6.c
+++ b/cpp6.c
@@ -42,19 +42,19 @@ INLINE FILE_LOCAL void domsg(struct Global *, ErrorCode, va_list);
  * fpp_catenate()   Does the dirty work of token concatenation, FPP_TRUE if it did.
  * fpp_scanstring() Reads a string from the input stream, calling
  *              a user-supplied function for each character.
- *              This function may be output() to write the
+ *              This function may be fpp_output() to write the
  *              string to the output file, or fpp_save() to fpp_save
  *              the string in the work buffer.
  * fpp_scannumber() Reads a C numeric constant from the input stream,
  *              calling the user-supplied function for each
- *              character.  (output() or fpp_save() as noted above.)
+ *              character.  (fpp_output() or fpp_save() as noted above.)
  * fpp_save()       Save one character in the work[] buffer.
  * fpp_savestring() Saves a string in malloc() memory.
  * fpp_getfile()    Initialize a new FILEINFO structure, called when
  *              #include opens a new file, or a macro is to be
  *              expanded.
  * fpp_Getmem()     Get a specified number of bytes from malloc memory.
- * output()     Write one character to stdout (calling fpp_Putchar) --
+ * fpp_output()     Write one character to stdout (calling fpp_Putchar) --
  *              implemented as a function so its address may be
  *              passed to fpp_scanstring() and fpp_scannumber().
  * fpp_lookid()     Scans the next token (identifier) from the input

--- a/cpp6.c
+++ b/cpp6.c
@@ -192,7 +192,7 @@ ReturnCode macroid(struct Global *global, int *c)
   if (global->infile != NULL && global->infile->fp != NULL)
     global->recursion = 0;
   while (type[*c] == LET && (dp = lookid(global, *c)) != NULL) {
-    if((ret=expand(global, dp)))
+    if((ret=fpp_expand(global, dp)))
       return(ret);
     *c = fpp_get(global);
   }

--- a/cpp6.c
+++ b/cpp6.c
@@ -49,7 +49,7 @@ INLINE FILE_LOCAL void domsg(struct Global *, ErrorCode, va_list);
  *              calling the user-supplied function for each
  *              character.  (output() or save() as noted above.)
  * save()       Save one character in the work[] buffer.
- * savestring() Saves a string in malloc() memory.
+ * fpp_savestring() Saves a string in malloc() memory.
  * fpp_getfile()    Initialize a new FILEINFO structure, called when
  *              #include opens a new file, or a macro is to be
  *              expanded.
@@ -221,7 +221,7 @@ int catenate(struct Global *global, int lhs_number, ReturnCode *ret)
   }
   else {
     if (lhs_number == 0) { /* The lhs number has already been emit */ 
-      token1 = savestring(global, global->tokenbuf); /* Save first token     */
+      token1 = fpp_savestring(global, global->tokenbuf); /* Save first token     */
     }
     c= fpp_get(global);
     if(global->rightconcat) {
@@ -480,7 +480,7 @@ ReturnCode save(struct Global *global, int c)
   return(FPP_OK);
 }
 
-char *savestring(struct Global *global, char *text)
+char *fpp_savestring(struct Global *global, char *text)
 {
   /*
    * Store a string into free memory.
@@ -515,7 +515,7 @@ ReturnCode fpp_getfile(struct Global *global,
     return(FPP_OUT_OF_MEMORY);
   (*file)->parent = global->infile;             /* Chain files together */
   (*file)->fp = NULL;                           /* No file yet          */
-  (*file)->filename = savestring(global, name); /* Save file/macro name */
+  (*file)->filename = fpp_savestring(global, name); /* Save file/macro name */
   (*file)->progname = NULL;                     /* No #line seen yet    */
   (*file)->unrecur = 0;                         /* No macro fixup       */
   (*file)->bptr = (*file)->buffer;              /* Initialize line ptr  */

--- a/cpp6.c
+++ b/cpp6.c
@@ -50,7 +50,7 @@ INLINE FILE_LOCAL void domsg(struct Global *, ErrorCode, va_list);
  *              character.  (output() or save() as noted above.)
  * save()       Save one character in the work[] buffer.
  * savestring() Saves a string in malloc() memory.
- * getfile()    Initialize a new FILEINFO structure, called when
+ * fpp_getfile()    Initialize a new FILEINFO structure, called when
  *              #include opens a new file, or a macro is to be
  *              expanded.
  * Getmem()     Get a specified number of bytes from malloc memory.
@@ -492,7 +492,7 @@ char *savestring(struct Global *global, char *text)
   return (result);
 }
 
-ReturnCode getfile(struct Global *global,
+ReturnCode fpp_getfile(struct Global *global,
                    size_t bufsize, /* Line or define buffer size   */
                    char *name,
                    FILEINFO **file) /* File or macro name string        */
@@ -959,7 +959,7 @@ ReturnCode fpp_ungetstring(struct Global *global, char *text)
   FILEINFO *file;
   ReturnCode ret;
 
-  ret = getfile(global, strlen(text) + 1, "", &file);
+  ret = fpp_getfile(global, strlen(text) + 1, "", &file);
   if(!ret)
     strcpy(file->buffer, text);
   return(ret);

--- a/cpp6.c
+++ b/cpp6.c
@@ -68,7 +68,7 @@ INLINE FILE_LOCAL void domsg(struct Global *, ErrorCode, va_list);
  *              comments appropriately.  Note that the global
  *              instring is -- essentially -- a parameter to fpp_get().
  * fpp_cget()       Like fpp_get(), but skip over TOK_SEP.
- * unget()      Push last gotten character back on the input stream.
+ * fpp_unget()      Push last gotten character back on the input stream.
  * cerror()     This routine format an print messages to the user.
  */
 
@@ -174,7 +174,7 @@ void scanid(struct Global *global,
       c = fpp_get(global);
     }
   while (type[c] == LET || type[c] == DIG);
-  unget(global);
+  fpp_unget(global);
   global->tokenbuf[ct] = EOS;
 }
 
@@ -205,7 +205,7 @@ int catenate(struct Global *global, int lhs_number, ReturnCode *ret)
    * A token was just read (via macroid).
    * If the next character is TOK_SEP, concatenate the next token
    * return FPP_TRUE -- which should recall macroid after refreshing
-   * macroid's argument.  If it is not TOK_SEP, unget() the character
+   * macroid's argument.  If it is not TOK_SEP, fpp_unget() the character
    * and return FPP_FALSE.
    */
 
@@ -216,7 +216,7 @@ int catenate(struct Global *global, int lhs_number, ReturnCode *ret)
 
 #if OK_CONCAT
   if (fpp_get(global) != TOK_SEP) {                 /* Token concatenation  */
-    unget(global);
+    fpp_unget(global);
     return (FPP_FALSE);
   }
   else {
@@ -258,7 +258,7 @@ int catenate(struct Global *global, int lhs_number, ReturnCode *ret)
       else
         cerror(global, ERROR_STRANG_CHARACTER2, c);
       strcpy(global->work, token1);
-      unget(global);
+      fpp_unget(global);
       break;
     }
     /*
@@ -316,7 +316,7 @@ ReturnCode scanstring(struct Global *global,
     return(ret);
   } else {
     cerror(global, ERROR_UNTERMINATED_STRING);
-    unget(global);
+    fpp_unget(global);
     return(FPP_UNTERMINATED_STRING);
   }
 }
@@ -348,7 +348,7 @@ ReturnCode scannumber(struct Global *global,
     if(ret)
       return(ret);
     if (type[(c = fpp_get(global))] != DIG) { /* If not a float numb, */
-      unget(global);                    /* Rescan strange char  */
+      fpp_unget(global);                    /* Rescan strange char  */
       return(FPP_OK);                   /* All done for now     */
     }
   }                                     /* End of float test    */
@@ -462,7 +462,7 @@ ReturnCode scannumber(struct Global *global,
       c = fpp_get(global);                /* Look at next, too.   */
     }
   }
-  unget(global);                         /* Not part of a number */
+  fpp_unget(global);                         /* Not part of a number */
   if(!(global->webmode)) {
     if (octal89 && radix == 8)
       cwarn(global, WARN_ILLEGAL_OCTAL);
@@ -557,7 +557,7 @@ DEFBUF *lookid(struct Global *global,
     nhash += c;                         /* Update hash value    */
     c = fpp_get(global);
   }  while (type[c] == LET || type[c] == DIG);
-  unget(global);                        /* Rescan terminator    */
+  fpp_unget(global);                        /* Rescan terminator    */
   global->tokenbuf[ct] = EOS;           /* Terminate token      */
   if (isrecurse)                        /* Recursive definition */
     return(NULL);                       /* undefined just now   */
@@ -812,7 +812,7 @@ int fpp_get(struct Global *global)
     if ( (c = fpp_get(global)) != '*' )
       if(!global->cplusplus || (global->cplusplus && c!='/')) {
         global->instring = FPP_FALSE;       /* Nope, no comment     */
-        unget(global);                  /* Push the char. back  */
+        fpp_unget(global);                  /* Push the char. back  */
         return ('/');                   /* Return the slash     */
       }
 
@@ -920,7 +920,7 @@ int fpp_get(struct Global *global)
       global->wrongline = FPP_TRUE;
       goto newline;
     } else {                            /* Backslash anything   */
-      unget(global);                    /* Get it later         */
+      fpp_unget(global);                    /* Get it later         */
       return ('\\');                    /* Return the backslash */
     }
   } else if (c == '\f' || c == VT)      /* Form Feed, Vertical  */
@@ -928,11 +928,11 @@ int fpp_get(struct Global *global)
   return (c);                           /* Just return the char */
 }
 
-void unget(struct Global *global)
+void fpp_unget(struct Global *global)
 {
   /*
    * Backup the pointer to reread the last character.  Fatal error
-   * (code bug) if we backup too far.  unget() may be called,
+   * (code bug) if we backup too far.  fpp_unget() may be called,
    * without problems, at end of file.  Only one character may
    * be ungotten.  If you need to unget more, call ungetstring().
    */

--- a/cpp6.c
+++ b/cpp6.c
@@ -1087,7 +1087,7 @@ void domsg(struct Global *global,
   for (file = global->infile; file && !file->fp; file = file->parent)
     ;
   tp = file ? file->filename : 0;
-  Error(global, "%s\"%s\", line %d: %s: ",
+  fpp_Error(global, "%s\"%s\", line %d: %s: ",
         MSG_PREFIX, tp, global->infile->fp?global->line:file->line, severity);
   if(global->error)
     global->error(global->userdata, ErrorMessage[error], arg);
@@ -1098,15 +1098,15 @@ void domsg(struct Global *global,
   else
     return;
 #endif
-  Error(global, "\n");
+  fpp_Error(global, "\n");
 
   if (file)   /*OIS*0.92*/
     while ((file = file->parent) != NULL) { /* Print #includes, too */
       tp = file->parent ? "," : ".";
       if (file->fp == NULL)
-        Error(global, " from macro %s%s\n", file->filename, tp);
+        fpp_Error(global, " from macro %s%s\n", file->filename, tp);
       else
-        Error(global, " from file %s, line %d%s\n",
+        fpp_Error(global, " from file %s, line %d%s\n",
               (file->progname != NULL) ? file->progname : file->filename,
               file->line, tp);
     }
@@ -1128,7 +1128,7 @@ void cerror(struct Global *global,
   domsg(global, message, arg);
 }
 
-void Error(struct Global *global, char *format, ...)
+void fpp_Error(struct Global *global, char *format, ...)
 {
   /*
    * Just get the arguments and send a decent string to the user error

--- a/cpp6.c
+++ b/cpp6.c
@@ -38,8 +38,8 @@ INLINE FILE_LOCAL void domsg(struct Global *, ErrorCode, va_list);
  *              never expanded.
  * macroid()    reads the next token (C identifier) into tokenbuf.
  *              If it is a #defined macro, it is expanded, and
- *              macroid() returns TRUE, otherwise, FALSE.
- * catenate()   Does the dirty work of token concatenation, TRUE if it did.
+ *              macroid() returns FPP_TRUE, otherwise, FPP_FALSE.
+ * catenate()   Does the dirty work of token concatenation, FPP_TRUE if it did.
  * scanstring() Reads a string from the input stream, calling
  *              a user-supplied function for each character.
  *              This function may be output() to write the
@@ -204,9 +204,9 @@ int catenate(struct Global *global, int lhs_number, ReturnCode *ret)
   /*
    * A token was just read (via macroid).
    * If the next character is TOK_SEP, concatenate the next token
-   * return TRUE -- which should recall macroid after refreshing
+   * return FPP_TRUE -- which should recall macroid after refreshing
    * macroid's argument.  If it is not TOK_SEP, unget() the character
-   * and return FALSE.
+   * and return FPP_FALSE.
    */
 
 #if OK_CONCAT
@@ -217,7 +217,7 @@ int catenate(struct Global *global, int lhs_number, ReturnCode *ret)
 #if OK_CONCAT
   if (get(global) != TOK_SEP) {                 /* Token concatenation  */
     unget(global);
-    return (FALSE);
+    return (FPP_FALSE);
   }
   else {
     if (lhs_number == 0) { /* The lhs number has already been emit */ 
@@ -227,7 +227,7 @@ int catenate(struct Global *global, int lhs_number, ReturnCode *ret)
     if(global->rightconcat) {
       *ret=macroid(global, &c);           /* Scan next token      */
       if(*ret)
-        return(FALSE);
+        return(FPP_FALSE);
     } /* BK - BUG? Parses token into global->tokenbuf but never uses it.
       else
       lookid(global, c);
@@ -237,7 +237,7 @@ int catenate(struct Global *global, int lhs_number, ReturnCode *ret)
       if ((int)strlen(token1) + (int)strlen(global->tokenbuf) >= NWORK) {
         cfatal(global, FATAL_WORK_AREA_OVERFLOW, token1);
         *ret=FPP_WORK_AREA_OVERFLOW;
-        return(FALSE);
+        return(FPP_FALSE);
       }
       sprintf(global->work, "%s%s", token1, global->tokenbuf);
       break;
@@ -247,10 +247,10 @@ int catenate(struct Global *global, int lhs_number, ReturnCode *ret)
       global->workp = global->work + strlen(global->work);
       *ret=scannumber(global, c, save);
       if(*ret)
-        return(FALSE);
+        return(FPP_FALSE);
       *ret=save(global, EOS);
       if(*ret)
-        return(FALSE);
+        return(FPP_FALSE);
       break;
     default:                            /* An error, ...        */
       if (isprint(c))
@@ -272,11 +272,11 @@ int catenate(struct Global *global, int lhs_number, ReturnCode *ret)
     }
     *ret=ungetstring(global, global->work);  /* Unget the new thing, */
     if(*ret)
-      return(FALSE);
-    return(TRUE);
+      return(FPP_FALSE);
+    return(FPP_TRUE);
   }
 #else
-  return(FALSE);                    /* Not supported        */
+  return(FPP_FALSE);                    /* Not supported        */
 #endif
 }
 
@@ -288,13 +288,13 @@ ReturnCode scanstring(struct Global *global,
   /*
    * Scan off a string.  Warning if terminated by newline or EOF.
    * outfun() outputs the character -- to a buffer if in a macro.
-   * TRUE if ok, FALSE if error.
+   * FPP_TRUE if ok, FPP_FALSE if error.
    */
 
   int c;
   ReturnCode ret;
 
-  global->instring = TRUE;              /* Don't strip comments         */
+  global->instring = FPP_TRUE;              /* Don't strip comments         */
   ret=(*outfun)(global, delim);
   if(ret)
     return(ret);
@@ -310,7 +310,7 @@ ReturnCode scanstring(struct Global *global,
         return(ret);
     }
   }
-  global->instring = FALSE;
+  global->instring = FPP_FALSE;
   if (c == delim) {
     ret=(*outfun)(global, c);
     return(ret);
@@ -335,15 +335,15 @@ ReturnCode scannumber(struct Global *global,
   int expseen;          /* 'e' seen in floater  */
   int signseen;         /* '+' or '-' seen      */
   int octal89;          /* For bad octal test   */
-  int dotflag;          /* TRUE if '.' was seen */
+  int dotflag;          /* FPP_TRUE if '.' was seen */
   ReturnCode ret;
-  char done=FALSE;
+  char done=FPP_FALSE;
 
-  expseen = FALSE;                      /* No exponent seen yet */
-  signseen = TRUE;                      /* No +/- allowed yet   */
-  octal89 = FALSE;                      /* No bad octal yet     */
+  expseen = FPP_FALSE;                      /* No exponent seen yet */
+  signseen = FPP_TRUE;                      /* No +/- allowed yet   */
+  octal89 = FPP_FALSE;                      /* No bad octal yet     */
   radix = 10;                           /* Assume decimal       */
-  if ((dotflag = (c == '.')) != FALSE) {/* . something?         */
+  if ((dotflag = (c == '.')) != FPP_FALSE) {/* . something?         */
     ret=(*outfun)(global, '.');         /* Always out the dot   */
     if(ret)
       return(ret);
@@ -374,24 +374,24 @@ ReturnCode scannumber(struct Global *global,
     if (radix != 16 && (c == 'e' || c == 'E')) {
       if (expseen)                      /* Already saw 'E'?     */
         break;                          /* Exit loop, bad nbr.  */
-      expseen = TRUE;                   /* Set exponent seen    */
-      signseen = FALSE;                 /* We can read '+' now  */
+      expseen = FPP_TRUE;                   /* Set exponent seen    */
+      signseen = FPP_FALSE;                 /* We can read '+' now  */
       radix = 10;                       /* Decimal exponent     */
     }
     else if (radix != 16 && c == '.') {
       if (dotflag)                      /* Saw dot already?     */
         break;                          /* Exit loop, two dots  */
-      dotflag = TRUE;                   /* Remember the dot     */
+      dotflag = FPP_TRUE;                   /* Remember the dot     */
       radix = 10;                       /* Decimal fraction     */
     }
     else if (c == '+' || c == '-') {    /* 1.0e+10              */
       if (signseen)                     /* Sign in wrong place? */
         break;                          /* Exit loop, not nbr.  */
-      /* signseen = TRUE; */            /* Remember we saw it   */
+      /* signseen = FPP_TRUE; */            /* Remember we saw it   */
     } else {                            /* Check the digit      */
       switch (c) {
       case '8': case '9':               /* Sometimes wrong      */
-        octal89 = TRUE;                 /* Do check later       */
+        octal89 = FPP_TRUE;                 /* Do check later       */
       case '0': case '1': case '2': case '3':
       case '4': case '5': case '6': case '7':
         break;                          /* Always ok            */
@@ -401,14 +401,14 @@ ReturnCode scannumber(struct Global *global,
         if (radix == 16)                /* Alpha's are ok only  */
           break;                        /* if reading hex.      */
       default:                          /* At number end        */
-        done=TRUE;                      /* Break from for loop  */
+        done=FPP_TRUE;                      /* Break from for loop  */
         continue;
       }                                 /* End of switch        */
     }                                   /* End general case     */
     ret=(*outfun)(global, c);           /* Accept the character */
     if(ret)
       return(ret);
-    signseen = TRUE;                    /* Don't read sign now  */
+    signseen = FPP_TRUE;                    /* Don't read sign now  */
     c = get(global);                    /* Read another char    */
   }                                     /* End of scan loop     */
   /*
@@ -433,27 +433,27 @@ ReturnCode scannumber(struct Global *global,
      * dotflag signals "saw 'L'", and
      * expseen signals "saw 'U'".
      */
-    done=TRUE;
+    done=FPP_TRUE;
     while(done) {
       switch (c) {
       case 'l':
       case 'L':
         if (dotflag) {
-          done=FALSE;
+          done=FPP_FALSE;
           continue;
         }
-        dotflag = TRUE;
+        dotflag = FPP_TRUE;
         break;
       case 'u':
       case 'U':
         if (expseen) {
-          done=FALSE;
+          done=FPP_FALSE;
           continue;
         }
-        expseen = TRUE;
+        expseen = FPP_TRUE;
         break;
       default:
-        done=FALSE;
+        done=FPP_FALSE;
         continue;
       }
       ret=(*outfun)(global, c);       /* Got 'L' or 'U'.      */
@@ -574,13 +574,13 @@ DEFBUF *lookid(struct Global *global,
 
 DEFBUF *defendel(struct Global *global,
                  char *name,
-                 int delete)            /* TRUE to delete a symbol */
+                 int delete)            /* FPP_TRUE to delete a symbol */
 {
   /*
-   * Enter this name in the lookup table (delete = FALSE)
-   * or delete this name (delete = TRUE).
-   * Returns a pointer to the define block (delete = FALSE)
-   * Returns NULL if the symbol wasn't defined (delete = TRUE).
+   * Enter this name in the lookup table (delete = FPP_FALSE)
+   * or delete this name (delete = FPP_TRUE).
+   * Returns a pointer to the define block (delete = FPP_FALSE)
+   * Returns NULL if the symbol wasn't defined (delete = FPP_TRUE).
    */
 
   DEFBUF *dp;
@@ -769,7 +769,7 @@ int get(struct Global *global)
            * is skipping over blank lines and will do a
            * #line at its convenience.
            */
-          global->wrongline = TRUE;     /* Need a #line now     */
+          global->wrongline = FPP_TRUE;     /* Need a #line now     */
         }
       }
     }
@@ -806,12 +806,12 @@ int get(struct Global *global)
   if (global->instring)                 /* Strings just return  */
     return (c);                         /* the character.       */
   else if (c == '/') {                  /* Comment?             */
-    global->instring = TRUE;            /* So get() won't loop  */
+    global->instring = FPP_TRUE;            /* So get() won't loop  */
 
     /* Check next byte for '*' and if(cplusplus) also '/' */
     if ( (c = get(global)) != '*' )
       if(!global->cplusplus || (global->cplusplus && c!='/')) {
-        global->instring = FALSE;       /* Nope, no comment     */
+        global->instring = FPP_FALSE;       /* Nope, no comment     */
         unget(global);                  /* Push the char. back  */
         return ('/');                   /* Return the slash     */
       }
@@ -820,7 +820,7 @@ int get(struct Global *global)
 
     if (global->keepcomments) {         /* If writing comments   */
 
-      global->comment = TRUE; /* information that a comment has been output */
+      global->comment = FPP_TRUE; /* information that a comment has been output */
       if(global->showspace) {
         /* Show all whitespaces! */
         global->spacebuf[global->chpos] = '\0';
@@ -843,7 +843,7 @@ int get(struct Global *global)
         if(global->keepcomments)
           Putchar(global, c);
       } while(c!='\n' && c!=EOF_CHAR);  /* eat all to EOL or EOF */
-      global->instring = FALSE;         /* End of comment        */
+      global->instring = FPP_FALSE;         /* End of comment        */
       return(c);                        /* Return the end char   */
     }
 
@@ -879,7 +879,7 @@ int get(struct Global *global)
           /* nested comment, continue! */
           break;
 
-        global->instring = FALSE;       /* End of comment,      */
+        global->instring = FPP_FALSE;       /* End of comment,      */
         /*
          * A comment is syntactically "whitespace" --
          * however, there are certain strange sequences
@@ -909,7 +909,7 @@ int get(struct Global *global)
 
       case '\n':                        /* we'll need a #line   */
         if (!global->keepcomments)
-          global->wrongline = TRUE;     /* later...             */
+          global->wrongline = FPP_TRUE;     /* later...             */
       default:                          /* Anything else is     */
         break;                          /* Just a character     */
       }                                 /* End switch           */
@@ -917,7 +917,7 @@ int get(struct Global *global)
   }                                     /* End if in comment    */
   else if (!global->inmacro && c == '\\') { /* If backslash, peek   */
     if ((c = get(global)) == '\n') {    /* for a <nl>.  If so,  */
-      global->wrongline = TRUE;
+      global->wrongline = FPP_TRUE;
       goto newline;
     } else {                            /* Backslash anything   */
       unget(global);                    /* Get it later         */

--- a/cpp6.c
+++ b/cpp6.c
@@ -645,32 +645,32 @@ void outadefine(struct Global *global, DEFBUF *dp)
   int c;
 
   /* printf("#define %s", dp->name); */
-  Putstring(global, "#define ");
-  Putstring(global, dp->name);
+  fpp_Putstring(global, "#define ");
+  fpp_Putstring(global, dp->name);
 
   if (dp->nargs > 0) {
     int i;
     fpp_Putchar(global, '(');
     for (i = 1; i < dp->nargs; i++) {
       /* printf("__%d,", i); */
-      Putstring(global, "__");
+      fpp_Putstring(global, "__");
       Putint(global, i);
       fpp_Putchar(global, ',');
     }
     /* printf("__%d)", i); */
-    Putstring(global, "__");
+    fpp_Putstring(global, "__");
     Putint(global, i);
     fpp_Putchar(global, ')');
 
   } else if (dp->nargs == 0) {
-    Putstring(global, "()");
+    fpp_Putstring(global, "()");
   }
   if (dp->repl != NULL) {
     fpp_Putchar(global, '\t');
     for (cp = dp->repl; (c = *cp++ & 0xFF) != EOS;) {
       if (c >= MAC_PARM && c < (MAC_PARM + PAR_MAC)) {
         /* printf("__%d", c - MAC_PARM + 1); */
-        Putstring(global, "__");
+        fpp_Putstring(global, "__");
         Putint(global, c - MAC_PARM + 1);
       } else if (isprint(c) || c == '\t' || c == '\n')
         fpp_Putchar(global, c);
@@ -683,20 +683,20 @@ void outadefine(struct Global *global, DEFBUF *dp)
         break;
       case COM_SEP:
 #if COMMENT_INVISIBLE
-        Putstring(global, "/**/");
+        fpp_Putstring(global, "/**/");
 #else
         fpp_Putchar(global, ' ');
 #endif
         break;
       case TOK_SEP:
-        Putstring(global, "##");
+        fpp_Putstring(global, "##");
         break;
       default:
         {
           /* Octal output! */
           char buffer[32];
           sprintf(buffer, "\\0%o", c);
-          Putstring(global, buffer);
+          fpp_Putstring(global, buffer);
         }
       }
     }
@@ -824,7 +824,7 @@ int fpp_get(struct Global *global)
       if(global->showspace) {
         /* Show all whitespaces! */
         global->spacebuf[global->chpos] = '\0';
-        Putstring(global, global->spacebuf);
+        fpp_Putstring(global, global->spacebuf);
       }
 
       if(c=='*') {

--- a/cpp6.c
+++ b/cpp6.c
@@ -764,7 +764,7 @@ int fpp_get(struct Global *global)
         if ((global->infile = file->parent) != NULL) {
           /*
            * There is an "ungotten" newline in the current
-           * infile buffer (set there by doinclude() in
+           * infile buffer (set there by fpp_doinclude() in
            * cpp1.c).  Thus, we know that the mainline code
            * is skipping over blank lines and will do a
            * #line at its convenience.

--- a/cpp6.c
+++ b/cpp6.c
@@ -628,7 +628,7 @@ void fpp_outdefines(struct Global *global)
   DEFBUF *dp;
   DEFBUF **syp;
 
-  deldefines(global);                   /* Delete built-in #defines     */
+  fpp_deldefines(global);                   /* Delete built-in #defines     */
   for (syp = global->symtab; syp < &global->symtab[SBSIZE]; syp++) {
     if ((dp = *syp) != (DEFBUF *) NULL) {
       do {

--- a/cpp6.c
+++ b/cpp6.c
@@ -34,11 +34,11 @@ INLINE FILE_LOCAL void domsg(struct Global *, ErrorCode, va_list);
  *              TOK_SEP, however (though that shouldn't happen).
  * fpp_scanid()     reads the next token (C identifier) into tokenbuf.
  *              The caller has already read the first character of
- *              the identifier.  Unlike macroid(), the token is
+ *              the identifier.  Unlike fpp_macroid(), the token is
  *              never expanded.
- * macroid()    reads the next token (C identifier) into tokenbuf.
+ * fpp_macroid()    reads the next token (C identifier) into tokenbuf.
  *              If it is a #defined macro, it is expanded, and
- *              macroid() returns FPP_TRUE, otherwise, FPP_FALSE.
+ *              fpp_macroid() returns FPP_TRUE, otherwise, FPP_FALSE.
  * fpp_catenate()   Does the dirty work of token concatenation, FPP_TRUE if it did.
  * fpp_scanstring() Reads a string from the input stream, calling
  *              a user-supplied function for each character.
@@ -178,7 +178,7 @@ void fpp_scanid(struct Global *global,
   global->tokenbuf[ct] = EOS;
 }
 
-ReturnCode macroid(struct Global *global, int *c)
+ReturnCode fpp_macroid(struct Global *global, int *c)
 {
   /*
    * If c is a letter, scan the id.  if it's #defined, expand it and scan
@@ -202,10 +202,10 @@ ReturnCode macroid(struct Global *global, int *c)
 int fpp_catenate(struct Global *global, int lhs_number, ReturnCode *ret)
 {
   /*
-   * A token was just read (via macroid).
+   * A token was just read (via fpp_macroid).
    * If the next character is TOK_SEP, concatenate the next token
-   * return FPP_TRUE -- which should recall macroid after refreshing
-   * macroid's argument.  If it is not TOK_SEP, fpp_unget() the character
+   * return FPP_TRUE -- which should recall fpp_macroid after refreshing
+   * fpp_macroid's argument.  If it is not TOK_SEP, fpp_unget() the character
    * and return FPP_FALSE.
    */
 
@@ -225,7 +225,7 @@ int fpp_catenate(struct Global *global, int lhs_number, ReturnCode *ret)
     }
     c= fpp_get(global);
     if(global->rightconcat) {
-      *ret=macroid(global, &c);           /* Scan next token      */
+      *ret=fpp_macroid(global, &c);           /* Scan next token      */
       if(*ret)
         return(FPP_FALSE);
     } /* BK - BUG? Parses token into global->tokenbuf but never uses it.

--- a/cpp6.c
+++ b/cpp6.c
@@ -43,12 +43,12 @@ INLINE FILE_LOCAL void domsg(struct Global *, ErrorCode, va_list);
  * scanstring() Reads a string from the input stream, calling
  *              a user-supplied function for each character.
  *              This function may be output() to write the
- *              string to the output file, or save() to save
+ *              string to the output file, or fpp_save() to fpp_save
  *              the string in the work buffer.
  * scannumber() Reads a C numeric constant from the input stream,
  *              calling the user-supplied function for each
- *              character.  (output() or save() as noted above.)
- * save()       Save one character in the work[] buffer.
+ *              character.  (output() or fpp_save() as noted above.)
+ * fpp_save()       Save one character in the work[] buffer.
  * fpp_savestring() Saves a string in malloc() memory.
  * fpp_getfile()    Initialize a new FILEINFO structure, called when
  *              #include opens a new file, or a macro is to be
@@ -245,10 +245,10 @@ int fpp_catenate(struct Global *global, int lhs_number, ReturnCode *ret)
     case DOT:                           /* Or maybe a float     */
       strcpy(global->work, token1);
       global->workp = global->work + strlen(global->work);
-      *ret=scannumber(global, c, save);
+      *ret=scannumber(global, c, fpp_save);
       if(*ret)
         return(FPP_FALSE);
-      *ret=save(global, EOS);
+      *ret=fpp_save(global, EOS);
       if(*ret)
         return(FPP_FALSE);
       break;
@@ -470,7 +470,7 @@ ReturnCode scannumber(struct Global *global,
   return(FPP_OK);
 }
 
-ReturnCode save(struct Global *global, int c)
+ReturnCode fpp_save(struct Global *global, int c)
 {
   if (global->workp >= &global->work[NWORK]) {
     fpp_cfatal(global, FATAL_WORK_BUFFER_OVERFLOW);

--- a/cpp6.c
+++ b/cpp6.c
@@ -67,7 +67,7 @@ INLINE FILE_LOCAL void domsg(struct Global *, ErrorCode, va_list);
  *              handling end of (macro/file) input and embedded
  *              comments appropriately.  Note that the global
  *              instring is -- essentially -- a parameter to fpp_get().
- * cget()       Like fpp_get(), but skip over TOK_SEP.
+ * fpp_cget()       Like fpp_get(), but skip over TOK_SEP.
  * unget()      Push last gotten character back on the input stream.
  * cerror()     This routine format an print messages to the user.
  */
@@ -965,7 +965,7 @@ ReturnCode ungetstring(struct Global *global, char *text)
   return(ret);
 }
 
-int cget(struct Global *global)
+int fpp_cget(struct Global *global)
 {
   /*
    * Get one character, absorb "funny space" after comments or

--- a/cpp6.c
+++ b/cpp6.c
@@ -270,7 +270,7 @@ int catenate(struct Global *global, int lhs_number, ReturnCode *ret)
     if (lhs_number == 0) {
       free(token1);                            /* Free up memory       */
     }
-    *ret=ungetstring(global, global->work);  /* Unget the new thing, */
+    *ret=fpp_ungetstring(global, global->work);  /* Unget the new thing, */
     if(*ret)
       return(FPP_FALSE);
     return(FPP_TRUE);
@@ -934,7 +934,7 @@ void fpp_unget(struct Global *global)
    * Backup the pointer to reread the last character.  Fatal error
    * (code bug) if we backup too far.  fpp_unget() may be called,
    * without problems, at end of file.  Only one character may
-   * be ungotten.  If you need to unget more, call ungetstring().
+   * be ungotten.  If you need to unget more, call fpp_ungetstring().
    */
 
   FILEINFO *file;
@@ -949,7 +949,7 @@ void fpp_unget(struct Global *global)
     --global->line;                     /* Unget the line number, too */
 }
 
-ReturnCode ungetstring(struct Global *global, char *text)
+ReturnCode fpp_ungetstring(struct Global *global, char *text)
 {
   /*
    * Push a string back on the input stream.  This is done by treating

--- a/cpp6.c
+++ b/cpp6.c
@@ -32,7 +32,7 @@ INLINE FILE_LOCAL void domsg(struct Global *, ErrorCode, va_list);
  * skipws()     skips over "whitespace" (spaces or tabs), but
  *              not skip over the end of the line.  It skips over
  *              TOK_SEP, however (though that shouldn't happen).
- * scanid()     reads the next token (C identifier) into tokenbuf.
+ * fpp_scanid()     reads the next token (C identifier) into tokenbuf.
  *              The caller has already read the first character of
  *              the identifier.  Unlike macroid(), the token is
  *              never expanded.
@@ -151,7 +151,7 @@ int skipws(struct Global *global)
  return(c);
 }
 
-void scanid(struct Global *global,
+void fpp_scanid(struct Global *global,
   int c)                                /* First char of id     */
 {
   /*

--- a/cppadd.h
+++ b/cppadd.h
@@ -391,7 +391,7 @@ ReturnCode save(struct Global *, int);
 void scanid(struct Global *, int);
 ReturnCode scannumber(struct Global *, int, ReturnCode(*)(struct Global *, int));
 ReturnCode scanstring(struct Global *, int, ReturnCode(*)(struct Global *, int));
-void unget(struct Global *);
+void fpp_unget(struct Global *);
 ReturnCode ungetstring(struct Global *, char *);
 ReturnCode eval(struct Global *, int *);
 #ifdef  DEBUG_EVAL

--- a/cppadd.h
+++ b/cppadd.h
@@ -389,7 +389,7 @@ ReturnCode fpp_initdefines(struct Global *);
 void fpp_outdefines(struct Global *);
 ReturnCode fpp_save(struct Global *, int);
 void scanid(struct Global *, int);
-ReturnCode scannumber(struct Global *, int, ReturnCode(*)(struct Global *, int));
+ReturnCode fpp_scannumber(struct Global *, int, ReturnCode(*)(struct Global *, int));
 ReturnCode scanstring(struct Global *, int, ReturnCode(*)(struct Global *, int));
 void fpp_unget(struct Global *);
 ReturnCode fpp_ungetstring(struct Global *, char *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -381,7 +381,7 @@ void fpp_cerror(struct Global *, ErrorCode, ...);
 ReturnCode fpp_control(struct Global *, int *);
 ReturnCode fpp_dodefine(struct Global *);
 int fpp_dooptions(struct Global *, struct fppTag *);
-void doundef(struct Global *);
+void fpp_doundef(struct Global *);
 void dumpparm(char *);
 ReturnCode expand(struct Global *, DEFBUF *);
 int fpp_get(struct Global *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -372,7 +372,7 @@ int PREFIX fppPreProcess(REG(a0) struct fppTag *);
 void fpp_Freemem(void *);
 void fpp_Error(struct Global *, char *, ...);
 void fpp_Putchar(struct Global *, int);
-void Putstring(struct Global *, char *);
+void fpp_Putstring(struct Global *, char *);
 void Putint(struct Global *, int);
 char *savestring(struct Global *, char *);
 ReturnCode addfile(struct Global *, FILE *, char *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -361,8 +361,8 @@ typedef enum {
 } ReturnCode;
 
 /* Nasty defines to make them appear as three different functions! */
-#define cwarn cerror
-#define cfatal cerror 
+#define fpp_cwarn fpp_cerror
+#define fpp_cfatal fpp_cerror 
 
 
 /**********************************************************************
@@ -377,7 +377,7 @@ void fpp_Putint(struct Global *, int);
 char *fpp_savestring(struct Global *, char *);
 ReturnCode fpp_addfile(struct Global *, FILE *, char *);
 int fpp_catenate(struct Global *, int lhs_number, ReturnCode *);
-void cerror(struct Global *, ErrorCode, ...);
+void fpp_cerror(struct Global *, ErrorCode, ...);
 ReturnCode control(struct Global *, int *);
 ReturnCode dodefine(struct Global *);
 int dooptions(struct Global *, struct fppTag *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -385,7 +385,7 @@ void fpp_doundef(struct Global *);
 void fpp_dumpparm(char *);
 ReturnCode fpp_expand(struct Global *, DEFBUF *);
 int fpp_get(struct Global *);
-ReturnCode initdefines(struct Global *);
+ReturnCode fpp_initdefines(struct Global *);
 void outdefines(struct Global *);
 ReturnCode save(struct Global *, int);
 void scanid(struct Global *, int);

--- a/cppadd.h
+++ b/cppadd.h
@@ -409,7 +409,7 @@ void fpp_dumpadef(char *, register DEFBUF *);
 #endif
 ReturnCode fpp_openfile(struct Global *,char *);
 int fpp_cget(struct Global *);
-void deldefines(struct Global *);
+void fpp_deldefines(struct Global *);
 char *Getmem(struct Global *, int);
 ReturnCode openinclude(struct Global *, char *, int);
 ReturnCode expstuff(struct Global *, char *, char *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -399,7 +399,7 @@ void fpp_dumpstack(OPTAB[NEXP], register OPTAB *, int [NEXP], register int *);
 #endif
 void fpp_skipnl(struct Global *);
 int fpp_skipws(struct Global *);
-ReturnCode macroid(struct Global *, int *);
+ReturnCode fpp_macroid(struct Global *, int *);
 ReturnCode fpp_getfile(struct Global *, size_t, char *, FILEINFO **);
 DEFBUF *lookid(struct Global *, int );
 DEFBUF *defendel(struct Global *, char *, int);

--- a/cppadd.h
+++ b/cppadd.h
@@ -95,7 +95,7 @@ struct Global {
    * shouldn't delimit tokens, but we'll worry about that some other
    * time -- it is more important to prevent infinitly long output lines.
    *
-   * instring and inmarcor are parameters to the get() routine which
+   * instring and inmarcor are parameters to the fpp_get() routine which
    * were made global for speed.
    */
   int           instring;       /* FPP_TRUE if scanning string      */
@@ -384,7 +384,7 @@ int dooptions(struct Global *, struct fppTag *);
 void doundef(struct Global *);
 void dumpparm(char *);
 ReturnCode expand(struct Global *, DEFBUF *);
-int get(struct Global *);
+int fpp_get(struct Global *);
 ReturnCode initdefines(struct Global *);
 void outdefines(struct Global *);
 ReturnCode save(struct Global *, int);

--- a/cppadd.h
+++ b/cppadd.h
@@ -370,7 +370,7 @@ typedef enum {
  *********************************************************************/
 int PREFIX fppPreProcess(REG(a0) struct fppTag *);
 void fpp_Freemem(void *);
-void Error(struct Global *, char *, ...);
+void fpp_Error(struct Global *, char *, ...);
 void Putchar(struct Global *, int);
 void Putstring(struct Global *, char *);
 void Putint(struct Global *, int);

--- a/cppadd.h
+++ b/cppadd.h
@@ -383,7 +383,7 @@ ReturnCode fpp_dodefine(struct Global *);
 int fpp_dooptions(struct Global *, struct fppTag *);
 void fpp_doundef(struct Global *);
 void fpp_dumpparm(char *);
-ReturnCode expand(struct Global *, DEFBUF *);
+ReturnCode fpp_expand(struct Global *, DEFBUF *);
 int fpp_get(struct Global *);
 ReturnCode initdefines(struct Global *);
 void outdefines(struct Global *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -376,7 +376,7 @@ void fpp_Putstring(struct Global *, char *);
 void fpp_Putint(struct Global *, int);
 char *fpp_savestring(struct Global *, char *);
 ReturnCode fpp_addfile(struct Global *, FILE *, char *);
-int catenate(struct Global *, int lhs_number, ReturnCode *);
+int fpp_catenate(struct Global *, int lhs_number, ReturnCode *);
 void cerror(struct Global *, ErrorCode, ...);
 ReturnCode control(struct Global *, int *);
 ReturnCode dodefine(struct Global *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -104,8 +104,8 @@ struct Global {
   /*
    * work[] and workp are used to store one piece of text in a temporay
    * buffer.  To initialize storage, set workp = work.  To store one
-   * character, call save(c);  (This will fatally exit if there isn't
-   * room.)  To terminate the string, call save(EOS).  Note that
+   * character, call fpp_save(c);  (This will fatally exit if there isn't
+   * room.)  To terminate the string, call fpp_save(EOS).  Note that
    * the work buffer is used by several subroutines -- be sure your
    * data won't be overwritten.  The extra byte in the allocation is
    * needed for string formal replacement.
@@ -387,7 +387,7 @@ ReturnCode fpp_expand(struct Global *, DEFBUF *);
 int fpp_get(struct Global *);
 ReturnCode fpp_initdefines(struct Global *);
 void fpp_outdefines(struct Global *);
-ReturnCode save(struct Global *, int);
+ReturnCode fpp_save(struct Global *, int);
 void scanid(struct Global *, int);
 ReturnCode scannumber(struct Global *, int, ReturnCode(*)(struct Global *, int));
 ReturnCode scanstring(struct Global *, int, ReturnCode(*)(struct Global *, int));

--- a/cppadd.h
+++ b/cppadd.h
@@ -380,7 +380,7 @@ int fpp_catenate(struct Global *, int lhs_number, ReturnCode *);
 void fpp_cerror(struct Global *, ErrorCode, ...);
 ReturnCode fpp_control(struct Global *, int *);
 ReturnCode fpp_dodefine(struct Global *);
-int dooptions(struct Global *, struct fppTag *);
+int fpp_dooptions(struct Global *, struct fppTag *);
 void doundef(struct Global *);
 void dumpparm(char *);
 ReturnCode expand(struct Global *, DEFBUF *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -401,7 +401,7 @@ void fpp_skipnl(struct Global *);
 int fpp_skipws(struct Global *);
 ReturnCode fpp_macroid(struct Global *, int *);
 ReturnCode fpp_getfile(struct Global *, size_t, char *, FILEINFO **);
-DEFBUF *lookid(struct Global *, int );
+DEFBUF *fpp_lookid(struct Global *, int );
 DEFBUF *defendel(struct Global *, char *, int);
 #if DEBUG
 void fpp_dumpdef(char *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -400,7 +400,7 @@ void dumpstack(OPTAB[NEXP], register OPTAB *, int [NEXP], register int *);
 void skipnl(struct Global *);
 int skipws(struct Global *);
 ReturnCode macroid(struct Global *, int *);
-ReturnCode getfile(struct Global *, size_t, char *, FILEINFO **);
+ReturnCode fpp_getfile(struct Global *, size_t, char *, FILEINFO **);
 DEFBUF *lookid(struct Global *, int );
 DEFBUF *defendel(struct Global *, char *, int);
 #if DEBUG

--- a/cppadd.h
+++ b/cppadd.h
@@ -404,7 +404,7 @@ ReturnCode fpp_getfile(struct Global *, size_t, char *, FILEINFO **);
 DEFBUF *lookid(struct Global *, int );
 DEFBUF *defendel(struct Global *, char *, int);
 #if DEBUG
-void dumpdef(char *);
+void fpp_dumpdef(char *);
 void dumpadef(char *, register DEFBUF *);
 #endif
 ReturnCode openfile(struct Global *,char *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -395,7 +395,7 @@ void fpp_unget(struct Global *);
 ReturnCode fpp_ungetstring(struct Global *, char *);
 ReturnCode fpp_eval(struct Global *, int *);
 #ifdef  DEBUG_EVAL
-void dumpstack(OPTAB[NEXP], register OPTAB *, int [NEXP], register int *);
+void fpp_dumpstack(OPTAB[NEXP], register OPTAB *, int [NEXP], register int *);
 #endif
 void skipnl(struct Global *);
 int skipws(struct Global *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -369,7 +369,7 @@ typedef enum {
  * PROTOTYPES:
  *********************************************************************/
 int PREFIX fppPreProcess(REG(a0) struct fppTag *);
-void Freemem(void *);
+void fpp_Freemem(void *);
 void Error(struct Global *, char *, ...);
 void Putchar(struct Global *, int);
 void Putstring(struct Global *, char *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -197,7 +197,7 @@ struct Global {
 
   DEFBUF *symtab[SBSIZE];       /* Symbol table queue headers   */
 
-  int evalue;                   /* Current value from evallex() */
+  int evalue;                   /* Current value from fpp_evallex() */
 
   void (*depends)(char *filename, void *); /* depends function */
 
@@ -393,7 +393,7 @@ ReturnCode fpp_scannumber(struct Global *, int, ReturnCode(*)(struct Global *, i
 ReturnCode fpp_scanstring(struct Global *, int, ReturnCode(*)(struct Global *, int));
 void fpp_unget(struct Global *);
 ReturnCode fpp_ungetstring(struct Global *, char *);
-ReturnCode eval(struct Global *, int *);
+ReturnCode fpp_eval(struct Global *, int *);
 #ifdef  DEBUG_EVAL
 void dumpstack(OPTAB[NEXP], register OPTAB *, int [NEXP], register int *);
 #endif

--- a/cppadd.h
+++ b/cppadd.h
@@ -397,7 +397,7 @@ ReturnCode fpp_eval(struct Global *, int *);
 #ifdef  DEBUG_EVAL
 void fpp_dumpstack(OPTAB[NEXP], register OPTAB *, int [NEXP], register int *);
 #endif
-void skipnl(struct Global *);
+void fpp_skipnl(struct Global *);
 int skipws(struct Global *);
 ReturnCode macroid(struct Global *, int *);
 ReturnCode fpp_getfile(struct Global *, size_t, char *, FILEINFO **);

--- a/cppadd.h
+++ b/cppadd.h
@@ -388,7 +388,7 @@ int fpp_get(struct Global *);
 ReturnCode fpp_initdefines(struct Global *);
 void fpp_outdefines(struct Global *);
 ReturnCode fpp_save(struct Global *, int);
-void scanid(struct Global *, int);
+void fpp_scanid(struct Global *, int);
 ReturnCode fpp_scannumber(struct Global *, int, ReturnCode(*)(struct Global *, int));
 ReturnCode fpp_scanstring(struct Global *, int, ReturnCode(*)(struct Global *, int));
 void fpp_unget(struct Global *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -386,7 +386,7 @@ void fpp_dumpparm(char *);
 ReturnCode fpp_expand(struct Global *, DEFBUF *);
 int fpp_get(struct Global *);
 ReturnCode fpp_initdefines(struct Global *);
-void outdefines(struct Global *);
+void fpp_outdefines(struct Global *);
 ReturnCode save(struct Global *, int);
 void scanid(struct Global *, int);
 ReturnCode scannumber(struct Global *, int, ReturnCode(*)(struct Global *, int));

--- a/cppadd.h
+++ b/cppadd.h
@@ -412,4 +412,4 @@ int fpp_cget(struct Global *);
 void fpp_deldefines(struct Global *);
 char *fpp_Getmem(struct Global *, int);
 ReturnCode fpp_openinclude(struct Global *, char *, int);
-ReturnCode expstuff(struct Global *, char *, char *);
+ReturnCode fpp_expstuff(struct Global *, char *, char *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -379,7 +379,7 @@ ReturnCode fpp_addfile(struct Global *, FILE *, char *);
 int fpp_catenate(struct Global *, int lhs_number, ReturnCode *);
 void fpp_cerror(struct Global *, ErrorCode, ...);
 ReturnCode fpp_control(struct Global *, int *);
-ReturnCode dodefine(struct Global *);
+ReturnCode fpp_dodefine(struct Global *);
 int dooptions(struct Global *, struct fppTag *);
 void doundef(struct Global *);
 void dumpparm(char *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -392,7 +392,7 @@ void scanid(struct Global *, int);
 ReturnCode scannumber(struct Global *, int, ReturnCode(*)(struct Global *, int));
 ReturnCode scanstring(struct Global *, int, ReturnCode(*)(struct Global *, int));
 void fpp_unget(struct Global *);
-ReturnCode ungetstring(struct Global *, char *);
+ReturnCode fpp_ungetstring(struct Global *, char *);
 ReturnCode eval(struct Global *, int *);
 #ifdef  DEBUG_EVAL
 void dumpstack(OPTAB[NEXP], register OPTAB *, int [NEXP], register int *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -402,7 +402,7 @@ int fpp_skipws(struct Global *);
 ReturnCode fpp_macroid(struct Global *, int *);
 ReturnCode fpp_getfile(struct Global *, size_t, char *, FILEINFO **);
 DEFBUF *fpp_lookid(struct Global *, int );
-DEFBUF *defendel(struct Global *, char *, int);
+DEFBUF *fpp_defendel(struct Global *, char *, int);
 #if DEBUG
 void fpp_dumpdef(char *);
 void fpp_dumpadef(char *, register DEFBUF *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -410,6 +410,6 @@ void fpp_dumpadef(char *, register DEFBUF *);
 ReturnCode fpp_openfile(struct Global *,char *);
 int fpp_cget(struct Global *);
 void fpp_deldefines(struct Global *);
-char *Getmem(struct Global *, int);
+char *fpp_Getmem(struct Global *, int);
 ReturnCode openinclude(struct Global *, char *, int);
 ReturnCode expstuff(struct Global *, char *, char *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -390,7 +390,7 @@ void fpp_outdefines(struct Global *);
 ReturnCode fpp_save(struct Global *, int);
 void scanid(struct Global *, int);
 ReturnCode fpp_scannumber(struct Global *, int, ReturnCode(*)(struct Global *, int));
-ReturnCode scanstring(struct Global *, int, ReturnCode(*)(struct Global *, int));
+ReturnCode fpp_scanstring(struct Global *, int, ReturnCode(*)(struct Global *, int));
 void fpp_unget(struct Global *);
 ReturnCode fpp_ungetstring(struct Global *, char *);
 ReturnCode eval(struct Global *, int *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -373,7 +373,7 @@ void fpp_Freemem(void *);
 void fpp_Error(struct Global *, char *, ...);
 void fpp_Putchar(struct Global *, int);
 void fpp_Putstring(struct Global *, char *);
-void Putint(struct Global *, int);
+void fpp_Putint(struct Global *, int);
 char *savestring(struct Global *, char *);
 ReturnCode addfile(struct Global *, FILE *, char *);
 int catenate(struct Global *, int lhs_number, ReturnCode *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -405,7 +405,7 @@ DEFBUF *lookid(struct Global *, int );
 DEFBUF *defendel(struct Global *, char *, int);
 #if DEBUG
 void fpp_dumpdef(char *);
-void dumpadef(char *, register DEFBUF *);
+void fpp_dumpadef(char *, register DEFBUF *);
 #endif
 ReturnCode openfile(struct Global *,char *);
 int fpp_cget(struct Global *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -398,7 +398,7 @@ ReturnCode fpp_eval(struct Global *, int *);
 void fpp_dumpstack(OPTAB[NEXP], register OPTAB *, int [NEXP], register int *);
 #endif
 void fpp_skipnl(struct Global *);
-int skipws(struct Global *);
+int fpp_skipws(struct Global *);
 ReturnCode macroid(struct Global *, int *);
 ReturnCode fpp_getfile(struct Global *, size_t, char *, FILEINFO **);
 DEFBUF *lookid(struct Global *, int );

--- a/cppadd.h
+++ b/cppadd.h
@@ -407,7 +407,7 @@ DEFBUF *fpp_defendel(struct Global *, char *, int);
 void fpp_dumpdef(char *);
 void fpp_dumpadef(char *, register DEFBUF *);
 #endif
-ReturnCode openfile(struct Global *,char *);
+ReturnCode fpp_openfile(struct Global *,char *);
 int fpp_cget(struct Global *);
 void deldefines(struct Global *);
 char *Getmem(struct Global *, int);

--- a/cppadd.h
+++ b/cppadd.h
@@ -408,7 +408,7 @@ void dumpdef(char *);
 void dumpadef(char *, register DEFBUF *);
 #endif
 ReturnCode openfile(struct Global *,char *);
-int cget(struct Global *);
+int fpp_cget(struct Global *);
 void deldefines(struct Global *);
 char *Getmem(struct Global *, int);
 ReturnCode openinclude(struct Global *, char *, int);

--- a/cppadd.h
+++ b/cppadd.h
@@ -411,5 +411,5 @@ ReturnCode fpp_openfile(struct Global *,char *);
 int fpp_cget(struct Global *);
 void fpp_deldefines(struct Global *);
 char *fpp_Getmem(struct Global *, int);
-ReturnCode openinclude(struct Global *, char *, int);
+ReturnCode fpp_openinclude(struct Global *, char *, int);
 ReturnCode expstuff(struct Global *, char *, char *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -371,7 +371,7 @@ typedef enum {
 int PREFIX fppPreProcess(REG(a0) struct fppTag *);
 void fpp_Freemem(void *);
 void fpp_Error(struct Global *, char *, ...);
-void Putchar(struct Global *, int);
+void fpp_Putchar(struct Global *, int);
 void Putstring(struct Global *, char *);
 void Putint(struct Global *, int);
 char *savestring(struct Global *, char *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -378,7 +378,7 @@ char *fpp_savestring(struct Global *, char *);
 ReturnCode fpp_addfile(struct Global *, FILE *, char *);
 int fpp_catenate(struct Global *, int lhs_number, ReturnCode *);
 void fpp_cerror(struct Global *, ErrorCode, ...);
-ReturnCode control(struct Global *, int *);
+ReturnCode fpp_control(struct Global *, int *);
 ReturnCode dodefine(struct Global *);
 int dooptions(struct Global *, struct fppTag *);
 void doundef(struct Global *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -67,7 +67,7 @@ struct Global {
   int           errors;                 /* cpp error counter            */
   FILEINFO      *infile;                /* Current input file           */
 #if DEBUG
-  int           debug;                  /* TRUE if debugging now        */
+  int           debug;                  /* FPP_TRUE if debugging now        */
 #endif
   /*
    * This counter is incremented when a macro expansion is initiated.
@@ -83,7 +83,7 @@ struct Global {
   int           rec_recover;            /* Unwind recursive macros      */
 
   /*
-   * instring is set TRUE when a string is scanned.  It modifies the
+   * instring is set FPP_TRUE when a string is scanned.  It modifies the
    * behavior of the "get next character" routine, causing all characters
    * to be passed to the caller (except <DEF_MAGIC>).  Note especially that
    * comments and \<newline> are not removed from the source.  (This
@@ -98,8 +98,8 @@ struct Global {
    * instring and inmarcor are parameters to the get() routine which
    * were made global for speed.
    */
-  int           instring;       /* TRUE if scanning string      */
-  int           inmacro;        /* TRUE if #defining a macro    */
+  int           instring;       /* FPP_TRUE if scanning string      */
+  int           inmacro;        /* FPP_TRUE if #defining a macro    */
   
   /*
    * work[] and workp are used to store one piece of text in a temporay
@@ -114,7 +114,7 @@ struct Global {
   char          *workp;                 /* Work buffer pointer          */
 
   /*
-   * keepcomments is set TRUE by the -C option.  If TRUE, comments
+   * keepcomments is set FPP_TRUE by the -C option.  If FPP_TRUE, comments
    * are written directly to the output stream.  This is needed if
    * the output from cpp is to be passed to lint (which uses commands
    * embedded in comments).  cflag contains the permanent state of the
@@ -138,10 +138,10 @@ struct Global {
    * ifstack[] holds information about nested #if's.  It is always
    * accessed via *ifptr.  The information is as follows:
    *    WAS_COMPILING   state of compiling flag at outer level.
-   *    ELSE_SEEN       set TRUE when #else seen to prevent 2nd #else.
-   *    TRUE_SEEN       set TRUE when #if or #elif succeeds
-   * ifstack[0] holds the compiling flag.  It is TRUE if compilation
-   * is currently enabled.  Note that this must be initialized TRUE.
+   *    ELSE_SEEN       set FPP_TRUE when #else seen to prevent 2nd #else.
+   *    FPP_TRUE_SEEN       set FPP_TRUE when #if or #elif succeeds
+   * ifstack[0] holds the compiling flag.  It is FPP_TRUE if compilation
+   * is currently enabled.  Note that this must be initialized FPP_TRUE.
    */
   char          ifstack[BLK_NEST];      /* #if information      */
   char          *ifptr;                 /* -> current ifstack[] */
@@ -176,7 +176,7 @@ struct Global {
 
   /*
    * This is the variable saying if Cpp should remove C++ style comments from
-   * the output. Default is... TRUE, yes, pronto, do it!!!
+   * the output. Default is... FPP_TRUE, yes, pronto, do it!!!
    */
   
   char cplusplus;
@@ -225,7 +225,7 @@ struct Global {
 
   char showspace;   /* display all whitespaces as they are */
 
-  char comment;     /* TRUE if a comment just has been written to output */
+  char comment;     /* FPP_TRUE if a comment just has been written to output */
 
   char *spacebuf;    /* Buffer to store whitespaces in if -H */
 
@@ -242,7 +242,7 @@ struct Global {
   char out; /* should we output anything now? */
 
   char rightconcat; /* should the right part of a concatenation be avaluated
-					   before the concat (TRUE) or after (FALSE) */
+					   before the concat (FPP_TRUE) or after (FPP_FALSE) */
   char *initialfunc; /* file to include first in all functions */
 
   char *excludedinit[20]; /* functions (names) excluded from the initfunc */

--- a/cppadd.h
+++ b/cppadd.h
@@ -375,7 +375,7 @@ void fpp_Putchar(struct Global *, int);
 void fpp_Putstring(struct Global *, char *);
 void fpp_Putint(struct Global *, int);
 char *fpp_savestring(struct Global *, char *);
-ReturnCode addfile(struct Global *, FILE *, char *);
+ReturnCode fpp_addfile(struct Global *, FILE *, char *);
 int catenate(struct Global *, int lhs_number, ReturnCode *);
 void cerror(struct Global *, ErrorCode, ...);
 ReturnCode control(struct Global *, int *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -382,7 +382,7 @@ ReturnCode fpp_control(struct Global *, int *);
 ReturnCode fpp_dodefine(struct Global *);
 int fpp_dooptions(struct Global *, struct fppTag *);
 void fpp_doundef(struct Global *);
-void dumpparm(char *);
+void fpp_dumpparm(char *);
 ReturnCode expand(struct Global *, DEFBUF *);
 int fpp_get(struct Global *);
 ReturnCode initdefines(struct Global *);

--- a/cppadd.h
+++ b/cppadd.h
@@ -374,7 +374,7 @@ void fpp_Error(struct Global *, char *, ...);
 void fpp_Putchar(struct Global *, int);
 void fpp_Putstring(struct Global *, char *);
 void fpp_Putint(struct Global *, int);
-char *savestring(struct Global *, char *);
+char *fpp_savestring(struct Global *, char *);
 ReturnCode addfile(struct Global *, FILE *, char *);
 int catenate(struct Global *, int lhs_number, ReturnCode *);
 void cerror(struct Global *, ErrorCode, ...);

--- a/cppdef.h
+++ b/cppdef.h
@@ -35,9 +35,9 @@
 /* Convert Emacs's conventions for BIG_ENDIAN to cpp's convention.  */
 #ifdef BIG_ENDIAN
 #undef BIG_ENDIAN
-#define BIG_ENDIAN TRUE
+#define BIG_ENDIAN FPP_TRUE
 #else /* not BIG_ENDIAN */
-#define BIG_ENDIAN FALSE
+#define BIG_ENDIAN FPP_FALSE
 #endif /* BIG_ENDIAN */
 
 /* Emacs uses the names index and rindex and defines them as str(r)chr if nec;
@@ -73,12 +73,12 @@
  */
 
 /*
- * This redundant definition of TRUE and FALSE works around
+ * This redundant definition of FPP_TRUE and FPP_FALSE works around
  * a limitation of Decus C.
  */
-#ifndef TRUE
-#define TRUE			1
-#define FALSE			0
+#ifndef FPP_TRUE
+#define FPP_TRUE			1
+#define FPP_FALSE			0
 #endif
 
 /*
@@ -134,27 +134,27 @@
  *		to be marked "static" even though they are referenced
  *		by "extern" statements elsewhere.
  *
- * OK_DOLLAR	Should be set TRUE if $ is a valid alphabetic character
+ * OK_DOLLAR	Should be set FPP_TRUE if $ is a valid alphabetic character
  *		in identifiers (default), or zero if $ is invalid.
- *		Default is TRUE.
+ *		Default is FPP_TRUE.
  *
- * OK_CONCAT	Should be set TRUE if # may be used to concatenate
+ * OK_CONCAT	Should be set FPP_TRUE if # may be used to concatenate
  *		tokens in macros (per the Ansi Draft Standard) or
- *		FALSE for old-style # processing (needed if cpp is
+ *		FPP_FALSE for old-style # processing (needed if cpp is
  *		to process assembler source code).
  */
-#define OK_CONCAT TRUE
+#define OK_CONCAT FPP_TRUE
 /*
- * OK_DATE	Predefines the compilation date if set TRUE.
+ * OK_DATE	Predefines the compilation date if set FPP_TRUE.
  *		Not permitted by the Nov. 12, 1984 Draft Standard.
  */
-#define OK_DATE TRUE
+#define OK_DATE FPP_TRUE
 /*
  *
  * OK_SIZEOF	Permits sizeof in #if preprocessor expressions.
  *		According to K&R V2 (page 232), this is not allowed.
  */
-#define OK_SIZEOF TRUE
+#define OK_SIZEOF FPP_TRUE
 /*
  * S_CHAR etc.	Define the sizeof the basic TARGET machine word types.
  *		By default, sizes are set to the values for the HOST
@@ -188,9 +188,9 @@
  */
 
 #if	OLD_PREPROCESSOR
-#define OK_DOLLAR		FALSE
-#define OK_CONCAT		FALSE
-#define COMMENT_INVISIBLE	TRUE
+#define OK_DOLLAR		FPP_FALSE
+#define OK_CONCAT		FPP_FALSE
+#define COMMENT_INVISIBLE	FPP_TRUE
 #endif
 
 /*
@@ -209,15 +209,15 @@
 #endif
 
 /*
- * BIG_ENDIAN is set TRUE on machines (such as the IBM 360 series)
+ * BIG_ENDIAN is set FPP_TRUE on machines (such as the IBM 360 series)
  * where 'ab' stores 'a' in the high-bits and 'b' in the low-bits.
- * It is set FALSE on machines (such as the PDP-11 and Vax-11)
+ * It is set FPP_FALSE on machines (such as the PDP-11 and Vax-11)
  * where 'ab' stores 'a' in the low-bits and 'b' in the high-bits.
  * (Or is it the other way around?) -- Warning: BIG_ENDIAN code is untested.
  * [I *seems* to be the other way around, according to the code /OIS]
  */
 #ifndef BIG_ENDIAN
-#define BIG_ENDIAN		FALSE
+#define BIG_ENDIAN		FPP_FALSE
 #endif
 
 /*
@@ -227,27 +227,27 @@
  * expansions.	This was removed from the Draft Ansi Standard.
  */
 #ifndef COMMENT_INVISIBLE
-#define COMMENT_INVISIBLE	FALSE
+#define COMMENT_INVISIBLE	FPP_FALSE
 #endif
 
 /*
  * OK_DOLLAR enables use of $ as a valid "letter" in identifiers.
  * This is a permitted extension to the Ansi Standard and is required
- * for e.g., VMS, RSX-11M, etc.   It should be set FALSE if cpp is
+ * for e.g., VMS, RSX-11M, etc.   It should be set FPP_FALSE if cpp is
  * used to preprocess assembler source on Unix systems.  OLD_PREPROCESSOR
- * sets OK_DOLLAR FALSE for that reason.
+ * sets OK_DOLLAR FPP_FALSE for that reason.
  */
 #ifndef OK_DOLLAR
-#define OK_DOLLAR		TRUE
+#define OK_DOLLAR		FPP_TRUE
 #endif
 
 /*
  * OK_CONCAT enables (one possible implementation of) token concatenation.
  * If cpp is used to preprocess Unix assembler source, this should be
- * set FALSE as the concatenation character, #, is used by the assembler.
+ * set FPP_FALSE as the concatenation character, #, is used by the assembler.
  */
 #ifndef OK_CONCAT
-#define OK_CONCAT		TRUE
+#define OK_CONCAT		FPP_TRUE
 #endif
 
 /*
@@ -256,7 +256,7 @@
  * by the Draft Ansi Standard.
  */
 #ifndef OK_DATE
-#define OK_DATE 	TRUE
+#define OK_DATE 	FPP_TRUE
 #endif
 
 /*
@@ -267,7 +267,7 @@
  * This option was added in the PDC process, under no. *OIS*0.92*.
  */
 #ifndef OK_SIZEOF
-#define OK_SIZEOF	FALSE
+#define OK_SIZEOF	FPP_FALSE
 #endif
 
 /*
@@ -275,7 +275,7 @@
  */
 
 #ifndef DEBUG
-#define DEBUG		FALSE
+#define DEBUG		FPP_FALSE
 #endif
 
 /*

--- a/fpp.h
+++ b/fpp.h
@@ -44,12 +44,12 @@ struct fppTag {
   void *data;
 };
 
-#ifndef TRUE
-#define TRUE 1
+#ifndef FPP_TRUE
+#define FPP_TRUE 1
 #endif
 
-#ifndef FALSE
-#define FALSE 0
+#ifndef FPP_FALSE
+#define FPP_FALSE 0
 #endif
 
 #define NFLAG_BUILTIN   1
@@ -59,26 +59,26 @@ struct fppTag {
 #define FPPTAG_END 0
 
 /* To make the preprocessed output keep the comments: */
-#define FPPTAG_KEEPCOMMENTS 1 /* data is TRUE or FALSE */
+#define FPPTAG_KEEPCOMMENTS 1 /* data is FPP_TRUE or FPP_FALSE */
 
 /* To define symbols to the preprocessor: */
 #define FPPTAG_DEFINE 2 /* data is the string "symbol" or "symbol=<value>" */
 
 /* To make the preprocessor ignore all non-fatal errors: */
-#define FPPTAG_IGNORE_NONFATAL 3 /* data is TRUE or FALSE */
+#define FPPTAG_IGNORE_NONFATAL 3 /* data is FPP_TRUE or FPP_FALSE */
 
 /* To add an include directory to the include directory list: */
 #define FPPTAG_INCLUDE_DIR 4 /* data is directory name ending with a '/' (on
 				amiga a ':' is also valid) */
 
-/* To define all machine specific built-in #defines, default is TRUE: */
-#define FPPTAG_BUILTINS 5 /* data is TRUE or FALSE */
+/* To define all machine specific built-in #defines, default is FPP_TRUE: */
+#define FPPTAG_BUILTINS 5 /* data is FPP_TRUE or FPP_FALSE */
 
-/* To define predefines like __LINE__, __DATE__, etc. default is TRUE: */
-#define FPPTAG_PREDEFINES 6 /* data is TRUE or FALSE */
+/* To define predefines like __LINE__, __DATE__, etc. default is FPP_TRUE: */
+#define FPPTAG_PREDEFINES 6 /* data is FPP_TRUE or FPP_FALSE */
 
 /* To make fpp leave C++ comments in the output: */
-#define FPPTAG_IGNORE_CPLUSPLUS 7 /* data is TRUE or FALSE */
+#define FPPTAG_IGNORE_CPLUSPLUS 7 /* data is FPP_TRUE or FPP_FALSE */
 
 /* To define new sizes to #if sizeof: */
 #define FPPTAG_SIZEOF_TABLE 8 /* data is sizeof table string */
@@ -87,7 +87,7 @@ struct fppTag {
 #define FPPTAG_UNDEFINE 9 /* data is symbol name */
 
 /* Output all #defines: */
-#define FPPTAG_OUTPUT_DEFINES 10 /* data is TRUE or FALSE */
+#define FPPTAG_OUTPUT_DEFINES 10 /* data is FPP_TRUE or FPP_FALSE */
 
 /* Initial input file name: */
 #define FPPTAG_INPUT_NAME 11 /* data is string */
@@ -101,42 +101,42 @@ struct fppTag {
 /* User data, sent in the last argument to the input function: */
 #define FPPTAG_USERDATA 14 /* data is user data */
 
-/* Whether to exclude #line instructions in the output, default is FALSE */
-#define FPPTAG_LINE 15 /* data is TRUE or FALSE */
+/* Whether to exclude #line instructions in the output, default is FPP_FALSE */
+#define FPPTAG_LINE 15 /* data is FPP_TRUE or FPP_FALSE */
 
 /* Error function. This is called when FPP finds any warning/error/fatal: */
 #define FPPTAG_ERROR 16 /* data is function pointer to a
 			   "void (*)(void *, char *, va_list)" */
 
 /* Whether to warn for illegal cpp instructions */
-#define FPPTAG_WARNILLEGALCPP 17 /* data is boolean, default is FALSE */
+#define FPPTAG_WARNILLEGALCPP 17 /* data is boolean, default is FPP_FALSE */
 
 /* Output the 'line' keyword on #line-lines? */
-#define FPPTAG_OUTPUTLINE 18 /* data is boolean, default is TRUE */
+#define FPPTAG_OUTPUTLINE 18 /* data is boolean, default is FPP_TRUE */
 
 /* Output the version information string */
-#define FPPTAG_SHOWVERSION 19 /* data is boolean, default is TRUE */
+#define FPPTAG_SHOWVERSION 19 /* data is boolean, default is FPP_TRUE */
 
 /* Output all included file names to stderr */
-#define FPPTAG_OUTPUTINCLUDES 20 /* data is boolean, default is FALSE */
+#define FPPTAG_OUTPUTINCLUDES 20 /* data is boolean, default is FPP_FALSE */
 
 /* Display warning if there is any brace, bracket or parentheses unbalance */
-#define FPPTAG_OUTPUTBALANCE 21 /* data is boolean, default is FALSE */
+#define FPPTAG_OUTPUTBALANCE 21 /* data is boolean, default is FPP_FALSE */
 
 /* Display all whitespaces in the source */
-#define FPPTAG_OUTPUTSPACE 22 /* data is boolean, default is FALSE */
+#define FPPTAG_OUTPUTSPACE 22 /* data is boolean, default is FPP_FALSE */
 
 /* Allow nested comments */
-#define FPPTAG_NESTED_COMMENTS 23 /* data is boolean, default is FALSE */
+#define FPPTAG_NESTED_COMMENTS 23 /* data is boolean, default is FPP_FALSE */
 
 /* Enable warnings at nested comments */
-#define FPPTAG_WARN_NESTED_COMMENTS 24 /* data is boolean, default is FALSE */
+#define FPPTAG_WARN_NESTED_COMMENTS 24 /* data is boolean, default is FPP_FALSE */
 
 /* Enable warnings at missing includes */
-#define FPPTAG_WARNMISSINCLUDE 25 /* data is boolean, default is TRUE */
+#define FPPTAG_WARNMISSINCLUDE 25 /* data is boolean, default is FPP_TRUE */
 
 /* Output the main file */
-#define FPPTAG_OUTPUTMAIN 26 /* data is boolean, default is TRUE */
+#define FPPTAG_OUTPUTMAIN 26 /* data is boolean, default is FPP_TRUE */
 
 /* Include file */
 #define FPPTAG_INCLUDE_FILE 27 /* data is char pointer */
@@ -145,7 +145,7 @@ struct fppTag {
 #define FPPTAG_INCLUDE_MACRO_FILE 28 /* data is char pointer */
 
 /* Evaluate the right part of a concatenate before the concat */
-#define FPPTAG_RIGHTCONCAT 29 /* data is boolean, default is FALSE */
+#define FPPTAG_RIGHTCONCAT 29 /* data is boolean, default is FPP_FALSE */
 
 /* Include the specified file at the beginning of each function */
 #define FPPTAG_INITFUNC 30 /* data is char pointer or NULL */
@@ -162,7 +162,7 @@ struct fppTag {
 /* Depends function: */
 #define FPPTAG_DEPENDS 34 /* data is an depends funtion */
 
-/* Allow include "X" (rather than <X>) to search local files, default is TRUE */
+/* Allow include "X" (rather than <X>) to search local files, default is FPP_TRUE */
 #define FPPTAG_ALLOW_INCLUDE_LOCAL 35
 
 int fppPreProcess(struct fppTag *);

--- a/usecpp.c
+++ b/usecpp.c
@@ -128,8 +128,8 @@ FILE_LOCAL char DoString(struct fppTag **, char *);
 extern long __stack=8000;
 #endif
 
-FILE_LOCAL char ignore=FALSE;  /* if we should ignore strange flags! */
-FILE_LOCAL char display=FALSE; /* display all options in use! */
+FILE_LOCAL char ignore=FPP_FALSE;  /* if we should ignore strange flags! */
+FILE_LOCAL char display=FPP_FALSE; /* display all options in use! */
 
 FILE_LOCAL char dontreadprefs; /* set if only the command line is valid */
 
@@ -369,37 +369,37 @@ int SetOptions(int argc, char **argv, struct fppTag **tagptr)
 
       case 'H':			      /* display all whitespaces */
 	(*tagptr)->tag = FPPTAG_OUTPUTSPACE;
-	(*tagptr)->data= (void *)TRUE;
+	(*tagptr)->data= (void *)FPP_TRUE;
 	(*tagptr)++;
 	break;
 
       case 'b': 		      /* display unbalance */
 	(*tagptr)->tag = FPPTAG_OUTPUTBALANCE;
-	(*tagptr)->data= (void *)TRUE;
+	(*tagptr)->data= (void *)FPP_TRUE;
 	(*tagptr)++;
 	break;
 
       case 'f':			      /* output all defined functions! */
 	(*tagptr)->tag = FPPTAG_DISPLAYFUNCTIONS;
-	(*tagptr)->data= (void *)TRUE;
+	(*tagptr)->data= (void *)FPP_TRUE;
 	(*tagptr)++;
         break;
 
       case 'F':			      /* output all included files! */
 	(*tagptr)->tag = FPPTAG_OUTPUTINCLUDES;
-	(*tagptr)->data= (void *)TRUE;
+	(*tagptr)->data= (void *)FPP_TRUE;
 	(*tagptr)++;
         break;
 
       case 'V':			      /* do not output version */
 	(*tagptr)->tag = FPPTAG_SHOWVERSION;
-	(*tagptr)->data= (void *)FALSE;
+	(*tagptr)->data= (void *)FPP_FALSE;
 	(*tagptr)++;
 	break;
 
       case 'C':                       /* Keep comments */
 	(*tagptr)->tag = FPPTAG_KEEPCOMMENTS;
-	(*tagptr)->data= (void *)TRUE;
+	(*tagptr)->data= (void *)FPP_TRUE;
 	(*tagptr)++;
 	break;
 	
@@ -411,12 +411,12 @@ int SetOptions(int argc, char **argv, struct fppTag **tagptr)
 
       case 'd':                       /* Display all options */
 	fprintf(stderr, "FOUND -d flag!\n");
-	display = TRUE;
+	display = FPP_TRUE;
 	break;
 	
       case 'E':                       /* Ignore non-fatal errors */
 	(*tagptr)->tag=FPPTAG_IGNORE_NONFATAL;
-	(*tagptr)->data=(void *)TRUE;
+	(*tagptr)->data=(void *)FPP_TRUE;
 	(*tagptr)++;
 	break;
 	
@@ -445,13 +445,13 @@ int SetOptions(int argc, char **argv, struct fppTag **tagptr)
 	  /* Do not output the 'line' keyword */
 	  (*tagptr)->tag=FPPTAG_OUTPUTLINE;
 	}
-	(*tagptr)->data=(void *)FALSE;
+	(*tagptr)->data=(void *)FPP_FALSE;
 	(*tagptr)++;
 	break;
 
       case 'M':                       /* Do not warn at missing includes */
 	(*tagptr)->tag=FPPTAG_WARNMISSINCLUDE;
-	(*tagptr)->data=(void *)FALSE;
+	(*tagptr)->data=(void *)FPP_FALSE;
 	(*tagptr)++;
 	break;
 
@@ -466,31 +466,31 @@ int SetOptions(int argc, char **argv, struct fppTag **tagptr)
 
       case 'N':                       /* No machine specific built-ins */
 	(*tagptr)->tag=FPPTAG_BUILTINS;
-	(*tagptr)->data=(void *)FALSE;
+	(*tagptr)->data=(void *)FPP_FALSE;
 	(*tagptr)++;
 	break;
 
       case 'B':			      /* No predefines like __LINE__, etc. */
 	(*tagptr)->tag=FPPTAG_PREDEFINES;
-	(*tagptr)->data=(void *)FALSE;
+	(*tagptr)->data=(void *)FPP_FALSE;
 	(*tagptr)++;
 	break;
 	
       case 'P':			      /* No C++ comments */
 	(*tagptr)->tag=FPPTAG_IGNORE_CPLUSPLUS;
-	(*tagptr)->data=(void *)TRUE;
+	(*tagptr)->data=(void *)FPP_TRUE;
 	(*tagptr)++;
 	break;
 	
       case 'p':			      /* warn about illegal # - instructions */
 	(*tagptr)->tag = FPPTAG_WARNILLEGALCPP;
-	(*tagptr)->data= (void *)TRUE;
+	(*tagptr)->data= (void *)FPP_TRUE;
 	(*tagptr)++;
 	break;
 
       case 'R':
 	(*tagptr)->tag = FPPTAG_RIGHTCONCAT;
-	(*tagptr)->data= (void *)TRUE;
+	(*tagptr)->data= (void *)FPP_TRUE;
 	(*tagptr)++;
 	break;
 
@@ -521,18 +521,18 @@ int SetOptions(int argc, char **argv, struct fppTag **tagptr)
       case 'w':			      /* Output all #defines but not the
 					 main file */
 	(*tagptr)->tag=FPPTAG_OUTPUTMAIN;
-	(*tagptr)->data=(void *)FALSE;
+	(*tagptr)->data=(void *)FPP_FALSE;
 	(*tagptr)++;
 	
       case 'W':			      /* Output all #defines */
         if(!strncmp(ap, "WW", 2)) {
           (*tagptr)->tag=FPPTAG_WEBMODE;
-          (*tagptr)->data=(void *)TRUE;
+          (*tagptr)->data=(void *)FPP_TRUE;
           (*tagptr)++;
         }
         else {
           (*tagptr)->tag=FPPTAG_OUTPUT_DEFINES;
-          (*tagptr)->data=(void *)TRUE;
+          (*tagptr)->data=(void *)FPP_TRUE;
           (*tagptr)++;
         }
 	break;


### PR DESCRIPTION
Hi,

This pull request adds the prefix `fpp_` to all the internal functions.
Reason: this avoids linker symbol clashes on function names such as `get`.

Cheers.