### PR TITLE
added custom callback for fileopen()

### DIFF
--- a/cpp3.c
+++ b/cpp3.c
@@ -35,7 +35,12 @@ ReturnCode openfile(struct Global *global, char *filename)
   FILE *fp;
   ReturnCode ret;
 
-  if ((fp = fopen(filename, "r")) == NULL)
+  if (global->openfile)
+    fp = global->openfile(filename, "r", global->userdata);
+  else
+    fp = fopen(filename, "r");
+
+  if (fp == NULL)
     ret=FPP_OPEN_ERROR;
   else
     ret=addfile(global, fp, filename);
@@ -267,6 +272,9 @@ int dooptions(struct Global *global, struct fppTag *tags)
       break;
     case FPPTAG_ALLOW_INCLUDE_LOCAL:
       global->allowincludelocal=(tags->data?1:0);
+      break;
+    case FPPTAG_FILEOPENFUNC:
+      global->openfile = (FILE* (*)(char *,char *))tags->data;
       break;
     default:
       cwarn(global, WARN_INTERNAL_ERROR, NULL);

--- a/cppadd.h
+++ b/cppadd.h
@@ -253,6 +253,8 @@ struct Global {
   char webmode; /* WWW process mode */
 
   char allowincludelocal;
+
+  FILE* (*openfile)(char *,char *, void *);
 };
 
 typedef enum {

--- a/fpp.h
+++ b/fpp.h
@@ -165,6 +165,10 @@ struct fppTag {
 /* Allow include "X" (rather than <X>) to search local files, default is TRUE */
 #define FPPTAG_ALLOW_INCLUDE_LOCAL 35
 
+/* Fileopen function. If set, this is called when FPP tries to open a file: */
+#define FPPTAG_FILEOPENFUNC 36 /* data is function pointer to a
+			   "FILE* (*)(char * filename, char * mode, void * userdata)", default is NULL */
+
 int fppPreProcess(struct fppTag *);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Hi,

this pull request adds a FPPTAG to submit is custom `fileopen` function.
Reason: this is useful for integration into any engine that rolls its own filesystem (where fopen does not work) or for embedding into environments where there are no local files (e.g. asm.js/webassembly).

Cheers.