### PR TITLE
small fixes for single header

### DIFF
--- a/cpp.h
+++ b/cpp.h
@@ -33,8 +33,10 @@
  * In general, definitions in this file should not be changed.
  */
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #ifndef fpp_toupper
 #define fpp_toupper(c) ((c) + ('A' - 'a'))
 #endif /* no fpp_toupper */

--- a/cpp1.c
+++ b/cpp1.c
@@ -22,11 +22,12 @@ SOFTWARE.
 
 #include <stdio.h>
 #include <ctype.h>
+
 #include "cppdef.h"
 #include "cpp.h"
 
 #if defined(AMIGA)
-#include        <dos.h>
+#include <dos.h>
 #if defined(SHARED)
 int _OSERR=0;
 char *_ProgramName="junk";

--- a/cpp2.c
+++ b/cpp2.c
@@ -19,10 +19,11 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ******************************************************************************/
-#include    <stdio.h>
-#include    <ctype.h>
-#include    "cppdef.h"
-#include    "cpp.h"
+#include <stdio.h>
+#include <ctype.h>
+
+#include "cppdef.h"
+#include "cpp.h"
 
 #ifdef _AMIGA
 #include <proto/dos.h>

--- a/cpp3.c
+++ b/cpp3.c
@@ -19,11 +19,12 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ******************************************************************************/
-#include        <stdio.h>
-#include        <ctype.h>
-#include        <time.h>        /*OIS*0.92*/
-#include        "cppdef.h"
-#include        "cpp.h"
+#include <stdio.h>
+#include <ctype.h>
+#include <time.h> /*OIS*0.92*/
+
+#include "cppdef.h"
+#include "cpp.h"
 
 ReturnCode fpp_openfile(struct Global *global, char *filename)
 {

--- a/cpp4.c
+++ b/cpp4.c
@@ -19,10 +19,11 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ******************************************************************************/
-#include	<stdio.h>
-#include	<ctype.h>
-#include	"cppdef.h"
-#include	"cpp.h"
+#include <stdio.h>
+#include <ctype.h>
+
+#include "cppdef.h"
+#include "cpp.h"
 
 INLINE FILE_LOCAL ReturnCode fpp_checkparm(struct Global *, int, DEFBUF *, int);
 INLINE FILE_LOCAL ReturnCode fpp_stparmscan(struct Global *, int);

--- a/cpp5.c
+++ b/cpp5.c
@@ -21,6 +21,7 @@ SOFTWARE.
 ******************************************************************************/
 #include <stdio.h>
 #include <ctype.h>
+
 #include "cppdef.h"
 #include "cpp.h"
 

--- a/cpp6.c
+++ b/cpp6.c
@@ -21,6 +21,7 @@ SOFTWARE.
 ******************************************************************************/
 #include <stdio.h>
 #include <ctype.h>
+
 #include "cppdef.h"
 #include "cpp.h"
 


### PR DESCRIPTION
Hi again,

this last pull request modifies a few spaces in `#include` lines so [Apporvaj's single header generator](http://apoorvaj.io/single-header-packer.html) works correctly.
Rationale: single header is useful when no automatic project generation solution is used.

Cheers.